### PR TITLE
Add unit tests for core modules

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1,0 +1,174 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/memory"
+)
+
+type stubModel struct {
+	response string
+	err      error
+}
+
+func (m *stubModel) Generate(ctx context.Context, prompt string) (any, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.response + " | " + prompt, nil
+}
+
+type stubTool struct {
+	name        string
+	description string
+}
+
+func (t *stubTool) Name() string        { return t.name }
+func (t *stubTool) Description() string { return t.description }
+func (t *stubTool) Run(ctx context.Context, input string) (string, error) {
+	return input, nil
+}
+
+type stubSubAgent struct {
+	name        string
+	description string
+}
+
+func (s *stubSubAgent) Name() string        { return s.name }
+func (s *stubSubAgent) Description() string { return s.description }
+func (s *stubSubAgent) Run(ctx context.Context, input string) (string, error) {
+	return input, nil
+}
+
+func TestNewAppliesDefaults(t *testing.T) {
+	model := &stubModel{response: "ok"}
+	mem := memory.NewSessionMemory(&memory.MemoryBank{}, 0)
+
+	agent, err := New(Options{Model: model, Memory: mem})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	if agent.systemPrompt == "" {
+		t.Fatalf("expected default system prompt to be applied")
+	}
+	if agent.contextLimit != 8 {
+		t.Fatalf("expected default context limit of 8, got %d", agent.contextLimit)
+	}
+}
+
+func TestNewRegistersToolsAndSubagents(t *testing.T) {
+	model := &stubModel{response: "ok"}
+	mem := memory.NewSessionMemory(&memory.MemoryBank{}, 4)
+
+	tool := &stubTool{name: "Echo", description: "desc"}
+	researcher := &stubSubAgent{name: "Researcher", description: "desc"}
+
+	agent, err := New(Options{
+		Model:     model,
+		Memory:    mem,
+		Tools:     []Tool{tool},
+		SubAgents: []SubAgent{researcher},
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	if _, ok := agent.tools["echo"]; !ok {
+		t.Fatalf("expected tool to be registered in lowercase")
+	}
+	if len(agent.toolOrder) != 1 || agent.toolOrder[0] != tool {
+		t.Fatalf("expected tool order to preserve insertion")
+	}
+
+	if _, ok := agent.subagents["researcher"]; !ok {
+		t.Fatalf("expected subagent to be registered in lowercase")
+	}
+	if len(agent.subagentOrder) != 1 || agent.subagentOrder[0] != researcher {
+		t.Fatalf("expected subagent order to preserve insertion")
+	}
+}
+
+func TestNewValidatesRequirements(t *testing.T) {
+	mem := memory.NewSessionMemory(&memory.MemoryBank{}, 0)
+	if _, err := New(Options{Memory: mem}); err == nil {
+		t.Fatalf("expected error when model is missing")
+	}
+	model := &stubModel{response: "ok"}
+	if _, err := New(Options{Model: model}); err == nil {
+		t.Fatalf("expected error when memory is missing")
+	}
+}
+
+func TestSplitCommand(t *testing.T) {
+	name, args := splitCommand("toolName   with extra spacing")
+	if name != "toolName" {
+		t.Fatalf("unexpected name: %q", name)
+	}
+	if args != "with extra spacing" {
+		t.Fatalf("unexpected args: %q", args)
+	}
+}
+
+func TestMetadataRole(t *testing.T) {
+	payload, _ := json.Marshal(map[string]string{"role": "assistant"})
+	role := metadataRole(string(payload))
+	if role != "assistant" {
+		t.Fatalf("expected role assistant, got %q", role)
+	}
+
+	if role := metadataRole("{invalid json}"); role != "unknown" {
+		t.Fatalf("expected fallback role unknown, got %q", role)
+	}
+
+	if role := metadataRole("{}"); role != "unknown" {
+		t.Fatalf("expected missing role to map to unknown, got %q", role)
+	}
+}
+
+func TestNewHonorsExplicitSettings(t *testing.T) {
+	model := &stubModel{response: "ok"}
+	mem := memory.NewSessionMemory(&memory.MemoryBank{}, 0)
+
+	agent, err := New(Options{Model: model, Memory: mem, SystemPrompt: "custom", ContextLimit: 2})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	if agent.systemPrompt != "custom" {
+		t.Fatalf("expected custom prompt, got %q", agent.systemPrompt)
+	}
+	if agent.contextLimit != 2 {
+		t.Fatalf("expected custom context limit, got %d", agent.contextLimit)
+	}
+}
+
+func TestToolsWithEmptyNamesAreSkipped(t *testing.T) {
+	model := &stubModel{response: "ok"}
+	mem := memory.NewSessionMemory(&memory.MemoryBank{}, 0)
+
+	tool := &stubTool{name: ""}
+	agent, err := New(Options{Model: model, Memory: mem, Tools: []Tool{tool}})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	if len(agent.tools) != 0 {
+		t.Fatalf("expected unnamed tool to be ignored")
+	}
+}
+
+func TestSubagentsWithEmptyNamesAreIgnored(t *testing.T) {
+	model := &stubModel{response: "ok"}
+	mem := memory.NewSessionMemory(&memory.MemoryBank{}, 0)
+
+	sub := &stubSubAgent{name: ""}
+	agent, err := New(Options{Model: model, Memory: mem, SubAgents: []SubAgent{sub}})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	if len(agent.subagents) != 0 {
+		t.Fatalf("expected unnamed subagent to be ignored")
+	}
+}

--- a/pkg/memory/memory_test.go
+++ b/pkg/memory/memory_test.go
@@ -1,0 +1,49 @@
+package memory
+
+import "testing"
+
+func TestDummyEmbeddingDeterministic(t *testing.T) {
+	first := DummyEmbedding("hello")
+	second := DummyEmbedding("hello")
+	if len(first) != 768 {
+		t.Fatalf("expected embedding length 768, got %d", len(first))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("expected deterministic output, mismatch at index %d", i)
+		}
+	}
+}
+
+func TestAddShortTermTrimsToLimit(t *testing.T) {
+	sm := NewSessionMemory(&MemoryBank{}, 3)
+
+	for i := 0; i < 5; i++ {
+		content := string(rune('A' + i))
+		sm.AddShortTerm("session", content, "{}", nil)
+	}
+
+	records := sm.shortTerm["session"]
+	if len(records) != 3 {
+		t.Fatalf("expected 3 records retained, got %d", len(records))
+	}
+	expected := []string{"C", "D", "E"}
+	for i, rec := range records {
+		if rec.Content != expected[i] {
+			t.Fatalf("unexpected record %d content: %q", i, rec.Content)
+		}
+	}
+}
+
+func TestTrimJSON(t *testing.T) {
+	cases := map[string]string{
+		"[1,2,3]":     "1,2,3",
+		"[[nested]]":  "nested",
+		"no brackets": "no brackets",
+	}
+	for input, want := range cases {
+		if got := trimJSON(input); got != want {
+			t.Fatalf("trimJSON(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -1,0 +1,45 @@
+package models
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewDummyLLMDefaultPrefix(t *testing.T) {
+	llm := NewDummyLLM("")
+	resp, err := llm.Generate(context.Background(), "line1\nline2")
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if got := resp.(string); got != "Dummy response: line2" {
+		t.Fatalf("unexpected response: %q", got)
+	}
+}
+
+func TestNewDummyLLMUsesLastNonEmptyLine(t *testing.T) {
+	llm := NewDummyLLM("Prefix:")
+	resp, err := llm.Generate(context.Background(), "first\n\nsecond\n  \nthird")
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if got := resp.(string); got != "Prefix: third" {
+		t.Fatalf("unexpected response: %q", got)
+	}
+}
+
+func TestNewLLMProviderErrorsOnUnknownProvider(t *testing.T) {
+	if _, err := NewLLMProvider(context.Background(), "unknown", "model", ""); err == nil {
+		t.Fatalf("expected error for unknown provider")
+	}
+}
+
+func TestDummyLLMHandlesEmptyPrompt(t *testing.T) {
+	llm := NewDummyLLM("Prefix")
+	resp, err := llm.Generate(context.Background(), "\n\n\n")
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if got := resp.(string); got != "Prefix <empty prompt>" {
+		t.Fatalf("unexpected response: %q", got)
+	}
+}

--- a/pkg/subagents/researcher_test.go
+++ b/pkg/subagents/researcher_test.go
@@ -1,0 +1,54 @@
+package subagents
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type fakeModel struct {
+	response any
+	err      error
+	prompts  []string
+}
+
+func (f *fakeModel) Generate(ctx context.Context, prompt string) (any, error) {
+	f.prompts = append(f.prompts, prompt)
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.response != nil {
+		return f.response, nil
+	}
+	return "ok", nil
+}
+
+func TestResearcherRunIncludesPersonaAndTask(t *testing.T) {
+	fm := &fakeModel{response: "result"}
+	researcher := NewResearcher(fm)
+
+	out, err := researcher.Run(context.Background(), "Investigate topic")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if out != "result" {
+		t.Fatalf("unexpected result: %q", out)
+	}
+	if len(fm.prompts) != 1 {
+		t.Fatalf("expected one prompt to be generated")
+	}
+	prompt := fm.prompts[0]
+	if !strings.Contains(prompt, researcher.persona) {
+		t.Fatalf("prompt missing persona text: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Investigate topic") {
+		t.Fatalf("prompt missing task text: %q", prompt)
+	}
+}
+
+func TestResearcherRunRequiresModel(t *testing.T) {
+	researcher := &Researcher{}
+	if _, err := researcher.Run(context.Background(), "anything"); err == nil {
+		t.Fatalf("expected error when model is missing")
+	}
+}

--- a/pkg/tools/tools_test.go
+++ b/pkg/tools/tools_test.go
@@ -1,0 +1,50 @@
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestEchoTool(t *testing.T) {
+	tool := &EchoTool{}
+	out, err := tool.Run(context.Background(), "  hello world  ")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if out != "hello world" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestCalculatorTool(t *testing.T) {
+	tool := &CalculatorTool{}
+	out, err := tool.Run(context.Background(), "21 / 3")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if out != "7" {
+		t.Fatalf("unexpected calculator result: %q", out)
+	}
+}
+
+func TestCalculatorToolErrors(t *testing.T) {
+	tool := &CalculatorTool{}
+	if _, err := tool.Run(context.Background(), "bad input"); err == nil {
+		t.Fatalf("expected format error")
+	}
+	if _, err := tool.Run(context.Background(), "1 / 0"); err == nil {
+		t.Fatalf("expected division by zero error")
+	}
+}
+
+func TestTimeTool(t *testing.T) {
+	tool := &TimeTool{}
+	out, err := tool.Run(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339, out); err != nil {
+		t.Fatalf("expected RFC3339 output, got %q: %v", out, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit coverage for agent setup helpers and validation logic
- exercise memory utilities including dummy embedding and JSON trimming
- cover dummy model selection, researcher subagent behavior, and built-in tools

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ecca959d488322b349bad84f70cdd3