### PR TITLE
Add mark3lab Model Context Protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ sub-agents so you can focus on domain logic instead of orchestration glue.
 - **Coordinator + specialists** – `pkg/agent` provides the core orchestration logic while `pkg/subagents`
   demonstrates how to bolt on personas such as a researcher that drafts background briefs.
 - **Tooling ecosystem** – Implement the `agent.Tool` interface and register it with the runtime. Reference
-  implementations (echo, calculator, clock) live in `pkg/tools`.
+  implementations (echo, calculator, clock) live in `pkg/tools`. A thin adapter for
+  [Model Context Protocol](https://modelcontextprotocol.io/) servers—compatible with
+  the mark3lab client API—is available via `pkg/mcp` and `pkg/tools/mcp.go`.
 - **Retrieval-augmented memory** – `pkg/memory` combines a short-term window with an optional Postgres + pgvector
   backend for long-term recall. The package gracefully degrades to in-memory only mode when a database is not
   provided (useful for tests and local hacking).
@@ -102,6 +104,13 @@ reply, _ := session.Ask(ctx, "How do I wire an agent?")
    Flags let you customise the coordinator model (`--model`), session identifier (`--session`), context limit
    (`--context`), and short-term memory window (`--window`). Provide additional prompts as positional arguments to
    override the default script.
+
+    To expose tools from an MCP server, pass the `--mcp-command` flag with the executable that implements the
+    protocol. Tool names are pulled from the server during startup and exposed directly to the coordinator.
+
+    ```bash
+    go run ./cmd/demo --mcp-command "./start-mcp-server"
+    ```
 
 ## Customisation Guide
 

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -1,0 +1,494 @@
+// Package mcp implements a lightweight Model Context Protocol client that is
+// compatible with the mark3lab reference implementation. It focuses on the
+// tooling surface area (listing and invoking tools) required by the agent
+// runtime.
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+const (
+	// protocolVersion loosely follows the Model Context Protocol releases. The
+	// value is intentionally flexible because servers may choose to accept a
+	// range of versions. A sensible default keeps the client working out of
+	// the box while still allowing tests to override it.
+	protocolVersion = "2024-05-01"
+)
+
+// ClientInfo describes the calling application when establishing an MCP
+// session.
+type ClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// Options control how the MCP client initialises the remote server.
+type Options struct {
+	ClientInfo      ClientInfo
+	Capabilities    map[string]any
+	ProtocolVersion string
+}
+
+// ToolDefinition mirrors the subset of the MCP tool schema that the runtime
+// requires.
+type ToolDefinition struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema,omitempty"`
+}
+
+// Content represents a single content part returned from a tool invocation.
+type Content struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text,omitempty"`
+	Data     json.RawMessage `json:"data,omitempty"`
+	MimeType string          `json:"mimeType,omitempty"`
+	Href     string          `json:"href,omitempty"`
+}
+
+// CallResult captures the structured output of an MCP tool invocation.
+type CallResult struct {
+	Content []Content `json:"content"`
+	IsError bool      `json:"isError,omitempty"`
+}
+
+// Text concatenates text parts within the result. Multiple segments are joined
+// with a newline to preserve ordering while offering a consumable string.
+func (r CallResult) Text() string {
+	var segments []string
+	for _, part := range r.Content {
+		if part.Type != "text" {
+			continue
+		}
+		if trimmed := strings.TrimSpace(part.Text); trimmed != "" {
+			segments = append(segments, trimmed)
+		}
+	}
+	return strings.Join(segments, "\n")
+}
+
+// JSON returns the first JSON payload embedded inside the call result. The
+// output is pretty printed for readability. When no JSON payload exists an
+// empty string is returned.
+func (r CallResult) JSON() string {
+	for _, part := range r.Content {
+		if part.Type != "json" || len(part.Data) == 0 {
+			continue
+		}
+		var buf bytes.Buffer
+		if err := json.Indent(&buf, part.Data, "", "  "); err != nil {
+			return string(part.Data)
+		}
+		return buf.String()
+	}
+	return ""
+}
+
+// PrimaryText returns the textual interpretation of the result. It prefers the
+// aggregated text segments but will fall back to the JSON payload if available.
+func (r CallResult) PrimaryText() string {
+	if txt := r.Text(); txt != "" {
+		return txt
+	}
+	return r.JSON()
+}
+
+// Transport is the underlying message transport used by the MCP client.
+type Transport interface {
+	Send(ctx context.Context, payload []byte) error
+	Receive(ctx context.Context) ([]byte, error)
+	Close() error
+}
+
+// Client implements a small subset of the Model Context Protocol focused on
+// listing and invoking tools.
+type Client struct {
+	transport    Transport
+	info         ClientInfo
+	capabilities map[string]any
+	protoVersion string
+
+	idCounter atomic.Uint64
+	mu        sync.Mutex
+	closed    atomic.Bool
+
+	serverInfo ServerInfo
+}
+
+// ServerInfo represents the metadata returned by the MCP server during the
+// initialise handshake.
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// NewClient creates an MCP client using the provided transport. The function
+// immediately performs the initialise handshake and will close the transport if
+// the handshake fails.
+func NewClient(ctx context.Context, transport Transport, opts Options) (*Client, error) {
+	if transport == nil {
+		return nil, errors.New("mcp: transport is nil")
+	}
+
+	info := opts.ClientInfo
+	if strings.TrimSpace(info.Name) == "" {
+		info.Name = "go-agent-development-kit"
+	}
+	if strings.TrimSpace(info.Version) == "" {
+		info.Version = "dev"
+	}
+
+	caps := opts.Capabilities
+	if caps == nil {
+		caps = map[string]any{
+			"tools": map[string]bool{
+				"list": true,
+				"call": true,
+			},
+		}
+	}
+
+	proto := opts.ProtocolVersion
+	if strings.TrimSpace(proto) == "" {
+		proto = protocolVersion
+	}
+
+	client := &Client{
+		transport:    transport,
+		info:         info,
+		capabilities: caps,
+		protoVersion: proto,
+	}
+
+	if err := client.initialize(ctx); err != nil {
+		transport.Close()
+		return nil, err
+	}
+
+	return client, nil
+}
+
+// Close releases the underlying transport. Close is idempotent.
+func (c *Client) Close() error {
+	if c == nil {
+		return nil
+	}
+	if c.closed.Load() {
+		return nil
+	}
+	c.closed.Store(true)
+	return c.transport.Close()
+}
+
+// Server returns metadata about the remote MCP server. The information is
+// captured during the initialise handshake.
+func (c *Client) Server() ServerInfo {
+	if c == nil {
+		return ServerInfo{}
+	}
+	return c.serverInfo
+}
+
+// ListTools retrieves the complete list of tools exposed by the MCP server.
+// The function transparently follows pagination cursors if the server elects to
+// paginate the response.
+func (c *Client) ListTools(ctx context.Context) ([]ToolDefinition, error) {
+	if err := c.ensureOpen(); err != nil {
+		return nil, err
+	}
+
+	var (
+		cursor string
+		tools  []ToolDefinition
+	)
+
+	for {
+		params := map[string]any{}
+		if cursor != "" {
+			params["cursor"] = cursor
+		}
+
+		var resp struct {
+			Tools      []ToolDefinition `json:"tools"`
+			NextCursor string           `json:"nextCursor,omitempty"`
+		}
+
+		if err := c.call(ctx, "tools/list", params, &resp); err != nil {
+			return nil, err
+		}
+
+		tools = append(tools, resp.Tools...)
+		if strings.TrimSpace(resp.NextCursor) == "" {
+			break
+		}
+		cursor = resp.NextCursor
+	}
+
+	return tools, nil
+}
+
+// CallTool invokes a named tool on the MCP server. The resulting CallResult is
+// returned alongside any transport level error. If the server indicates that
+// the invocation failed the function returns an error that includes the tool's
+// textual output.
+func (c *Client) CallTool(ctx context.Context, name string, arguments map[string]any) (CallResult, error) {
+	if err := c.ensureOpen(); err != nil {
+		return CallResult{}, err
+	}
+	if strings.TrimSpace(name) == "" {
+		return CallResult{}, errors.New("mcp: tool name is required")
+	}
+
+	params := map[string]any{
+		"name": name,
+	}
+	if len(arguments) > 0 {
+		params["arguments"] = arguments
+	}
+
+	var result CallResult
+	if err := c.call(ctx, "tools/call", params, &result); err != nil {
+		return CallResult{}, err
+	}
+
+	if result.IsError {
+		message := strings.TrimSpace(result.PrimaryText())
+		if message == "" {
+			message = "tool reported an error"
+		}
+		return result, fmt.Errorf("mcp: tool %s failed: %s", name, message)
+	}
+
+	return result, nil
+}
+
+// Shutdown notifies the server that the client intends to terminate the
+// session. Servers may choose to perform additional cleanup when this request
+// is received. Shutdown is best effort and errors are returned to the caller so
+// they can be logged.
+func (c *Client) Shutdown(ctx context.Context) error {
+	if err := c.ensureOpen(); err != nil {
+		return err
+	}
+	// A server may respond with an empty result which is perfectly valid for
+	// shutdown. We therefore ignore the decoded payload.
+	return c.call(ctx, "shutdown", map[string]any{}, &struct{}{})
+}
+
+// ensureOpen validates that the client has not been closed.
+func (c *Client) ensureOpen() error {
+	if c == nil {
+		return errors.New("mcp: client is nil")
+	}
+	if c.closed.Load() {
+		return errors.New("mcp: client has been closed")
+	}
+	return nil
+}
+
+func (c *Client) initialize(ctx context.Context) error {
+	params := map[string]any{
+		"protocolVersion": c.protoVersion,
+		"clientInfo":      c.info,
+		"capabilities":    c.capabilities,
+	}
+
+	var resp struct {
+		ProtocolVersion string     `json:"protocolVersion"`
+		ServerInfo      ServerInfo `json:"serverInfo"`
+	}
+
+	if err := c.call(ctx, "initialize", params, &resp); err != nil {
+		return err
+	}
+
+	c.serverInfo = resp.ServerInfo
+	return nil
+}
+
+type request struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      string      `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+type responseEnvelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      *string         `json:"id,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (c *Client) call(ctx context.Context, method string, params any, out any) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	id := strconv.FormatUint(c.idCounter.Add(1), 10)
+	payload, err := json.Marshal(request{JSONRPC: "2.0", ID: id, Method: method, Params: params})
+	if err != nil {
+		return fmt.Errorf("mcp: marshal request: %w", err)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if c.closed.Load() {
+		return errors.New("mcp: client has been closed")
+	}
+
+	if err := c.transport.Send(ctx, payload); err != nil {
+		return err
+	}
+
+	for {
+		msg, err := c.transport.Receive(ctx)
+		if err != nil {
+			return err
+		}
+
+		var env responseEnvelope
+		if err := json.Unmarshal(msg, &env); err != nil {
+			return fmt.Errorf("mcp: decode response: %w", err)
+		}
+
+		if env.Method != "" {
+			// Notification – ignore for now but keep looping to find the
+			// response that matches our request id.
+			continue
+		}
+
+		if env.ID == nil || *env.ID != id {
+			// Not the response we are waiting for. Keep looping until we
+			// encounter the correct ID.
+			continue
+		}
+
+		if env.Error != nil {
+			return errors.New(env.Error.Message)
+		}
+
+		if out != nil && len(env.Result) > 0 {
+			if err := json.Unmarshal(env.Result, out); err != nil {
+				return fmt.Errorf("mcp: decode result: %w", err)
+			}
+		}
+		return nil
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Transport implementations
+
+type stdioTransport struct {
+	reader       *bufio.Reader
+	writer       io.Writer
+	stdinCloser  io.Closer
+	stdoutCloser io.Closer
+	writeMu      sync.Mutex
+}
+
+func newStdioTransport(stdin io.WriteCloser, stdout io.ReadCloser) Transport {
+	return &stdioTransport{
+		reader:       bufio.NewReader(stdout),
+		writer:       stdin,
+		stdinCloser:  stdin,
+		stdoutCloser: stdout,
+	}
+}
+
+func (t *stdioTransport) Send(ctx context.Context, payload []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(payload))
+
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+
+	if _, err := io.WriteString(t.writer, header); err != nil {
+		return err
+	}
+	_, err := t.writer.Write(payload)
+	return err
+}
+
+func (t *stdioTransport) Receive(ctx context.Context) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	length, err := t.readContentLength()
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, length)
+	if _, err := io.ReadFull(t.reader, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func (t *stdioTransport) Close() error {
+	var err error
+	if t.stdinCloser != nil {
+		if e := t.stdinCloser.Close(); e != nil {
+			err = e
+		}
+	}
+	if t.stdoutCloser != nil {
+		if e := t.stdoutCloser.Close(); e != nil && err == nil {
+			err = e
+		}
+	}
+	return err
+}
+
+func (t *stdioTransport) readContentLength() (int, error) {
+	length := -1
+	for {
+		line, err := t.reader.ReadString('\n')
+		if err != nil {
+			return 0, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		if strings.HasPrefix(strings.ToLower(line), "content-length:") {
+			value := strings.TrimSpace(line[len("content-length:"):])
+			parsed, err := strconv.Atoi(value)
+			if err != nil {
+				return 0, fmt.Errorf("mcp: invalid content length: %w", err)
+			}
+			length = parsed
+		}
+	}
+	if length < 0 {
+		return 0, errors.New("mcp: missing Content-Length header")
+	}
+	return length, nil
+}

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -1,0 +1,246 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestClientListAndCall(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clientTransport, server := newInMemoryPair()
+
+	server.handle("initialize", func(id string, params json.RawMessage) (any, *rpcError) {
+		return map[string]any{
+			"protocolVersion": protocolVersion,
+			"serverInfo": map[string]string{
+				"name":    "mock-server",
+				"version": "1.0.0",
+			},
+		}, nil
+	})
+	server.handle("tools/list", func(id string, params json.RawMessage) (any, *rpcError) {
+		return map[string]any{
+			"tools": []ToolDefinition{{
+				Name:        "echo",
+				Description: "Echoes the provided input",
+			}},
+		}, nil
+	})
+	server.handle("tools/call", func(id string, params json.RawMessage) (any, *rpcError) {
+		var payload struct {
+			Name      string         `json:"name"`
+			Arguments map[string]any `json:"arguments"`
+		}
+		if err := json.Unmarshal(params, &payload); err != nil {
+			return nil, &rpcError{Code: -32602, Message: err.Error()}
+		}
+		if payload.Name != "echo" {
+			return nil, &rpcError{Code: -32001, Message: "unknown tool"}
+		}
+		input, _ := payload.Arguments["input"].(string)
+		return CallResult{
+			Content: []Content{{Type: "text", Text: fmt.Sprintf("echo:%s", input)}},
+		}, nil
+	})
+
+	go server.serve(ctx)
+
+	client, err := NewClient(ctx, clientTransport, Options{})
+	if err != nil {
+		t.Fatalf("NewClient error: %v", err)
+	}
+	defer client.Close()
+
+	tools, err := client.ListTools(ctx)
+	if err != nil {
+		t.Fatalf("ListTools error: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "echo" {
+		t.Fatalf("unexpected tools: %#v", tools)
+	}
+
+	result, err := client.CallTool(ctx, "echo", map[string]any{"input": "hello"})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if got := result.Text(); got != "echo:hello" {
+		t.Fatalf("unexpected result: %s", got)
+	}
+}
+
+func TestClientCallToolError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clientTransport, server := newInMemoryPair()
+
+	server.handle("initialize", func(id string, params json.RawMessage) (any, *rpcError) {
+		return map[string]any{
+			"protocolVersion": protocolVersion,
+			"serverInfo":      map[string]string{"name": "mock", "version": "1"},
+		}, nil
+	})
+	server.handle("tools/list", func(id string, params json.RawMessage) (any, *rpcError) {
+		return map[string]any{"tools": []ToolDefinition{}}, nil
+	})
+	server.handle("tools/call", func(id string, params json.RawMessage) (any, *rpcError) {
+		return CallResult{
+			IsError: true,
+			Content: []Content{{Type: "text", Text: "failure"}},
+		}, nil
+	})
+
+	go server.serve(ctx)
+
+	client, err := NewClient(ctx, clientTransport, Options{})
+	if err != nil {
+		t.Fatalf("NewClient error: %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.CallTool(ctx, "echo", map[string]any{"input": "hi"})
+	if err == nil || !strings.Contains(err.Error(), "failure") {
+		t.Fatalf("expected failure error, got %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+
+type inMemoryServer struct {
+	reader   *bufio.Reader
+	writer   io.Writer
+	handlers map[string]func(id string, params json.RawMessage) (any, *rpcError)
+	mu       sync.RWMutex
+}
+
+func newInMemoryPair() (Transport, *inMemoryServer) {
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+
+	transport := &stdioTransport{
+		reader:       bufio.NewReader(clientRead),
+		writer:       clientWrite,
+		stdinCloser:  clientWrite,
+		stdoutCloser: clientRead,
+	}
+
+	server := &inMemoryServer{
+		reader:   bufio.NewReader(serverRead),
+		writer:   serverWrite,
+		handlers: make(map[string]func(id string, params json.RawMessage) (any, *rpcError)),
+	}
+
+	return transport, server
+}
+
+func (s *inMemoryServer) handle(method string, fn func(id string, params json.RawMessage) (any, *rpcError)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.handlers[method] = fn
+}
+
+func (s *inMemoryServer) serve(ctx context.Context) {
+	for {
+		payload, err := readFrame(s.reader)
+		if err != nil {
+			return
+		}
+
+		var req request
+		if err := json.Unmarshal(payload, &req); err != nil {
+			resp := responseEnvelope{JSONRPC: "2.0", ID: &req.ID, Error: &rpcError{Code: -32700, Message: err.Error()}}
+			_ = writeFrame(s.writer, resp)
+			continue
+		}
+
+		s.mu.RLock()
+		handler := s.handlers[req.Method]
+		s.mu.RUnlock()
+
+		if handler == nil {
+			resp := responseEnvelope{JSONRPC: "2.0", ID: &req.ID, Error: &rpcError{Code: -32601, Message: "method not found"}}
+			_ = writeFrame(s.writer, resp)
+			continue
+		}
+
+		result, rpcErr := handler(req.ID, mustRaw(req.Params))
+		if rpcErr != nil {
+			resp := responseEnvelope{JSONRPC: "2.0", ID: &req.ID, Error: rpcErr}
+			_ = writeFrame(s.writer, resp)
+			continue
+		}
+
+		encoded, err := json.Marshal(result)
+		if err != nil {
+			resp := responseEnvelope{JSONRPC: "2.0", ID: &req.ID, Error: &rpcError{Code: -32603, Message: err.Error()}}
+			_ = writeFrame(s.writer, resp)
+			continue
+		}
+
+		resp := responseEnvelope{JSONRPC: "2.0", ID: &req.ID, Result: encoded}
+		_ = writeFrame(s.writer, resp)
+	}
+}
+
+func readFrame(r *bufio.Reader) ([]byte, error) {
+	length := -1
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		if strings.HasPrefix(strings.ToLower(line), "content-length:") {
+			value := strings.TrimSpace(line[len("content-length:"):])
+			n, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, err
+			}
+			length = n
+		}
+	}
+	if length < 0 {
+		return nil, errors.New("missing Content-Length header")
+	}
+	buf := make([]byte, length)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func writeFrame(w io.Writer, v responseEnvelope) error {
+	payload, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(payload))
+	if _, err := io.WriteString(w, header); err != nil {
+		return err
+	}
+	_, err = w.Write(payload)
+	return err
+}
+
+func mustRaw(v any) json.RawMessage {
+	if v == nil {
+		return nil
+	}
+	data, _ := json.Marshal(v)
+	return data
+}

--- a/pkg/mcp/stdio.go
+++ b/pkg/mcp/stdio.go
@@ -1,0 +1,81 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// StdioConfig describes how to spawn an MCP server using the stdio transport.
+type StdioConfig struct {
+	Command string
+	Args    []string
+	Dir     string
+	Env     []string
+
+	// Stderr, when provided, receives the standard error stream of the
+	// spawned server process. Defaults to os.Stderr if nil.
+	Stderr io.Writer
+
+	Options Options
+}
+
+// NewStdioClient starts the configured command and binds the stdin/stdout pipes
+// to the MCP client transport. The caller is responsible for invoking Close on
+// the returned client when the session should end. Any failure during
+// initialisation stops the process and returns an error.
+func NewStdioClient(ctx context.Context, cfg StdioConfig) (*Client, error) {
+	if strings.TrimSpace(cfg.Command) == "" {
+		return nil, errors.New("mcp: stdio command is required")
+	}
+
+	cmd := exec.CommandContext(ctx, cfg.Command, cfg.Args...)
+	cmd.Dir = cfg.Dir
+	if len(cfg.Env) > 0 {
+		cmd.Env = append(os.Environ(), cfg.Env...)
+	}
+	if cfg.Stderr != nil {
+		cmd.Stderr = cfg.Stderr
+	} else {
+		cmd.Stderr = os.Stderr
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: stdout pipe: %w", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: stdin pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("mcp: start command: %w", err)
+	}
+
+	transport := newStdioTransport(stdin, stdout)
+	client, err := NewClient(ctx, transport, cfg.Options)
+	if err != nil {
+		transport.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, err
+	}
+
+	// Ensure the transport is closed when the process exits to unblock any
+	// pending reads.
+	var once sync.Once
+	go func() {
+		_ = cmd.Wait()
+		once.Do(func() {
+			_ = transport.Close()
+		})
+	}()
+
+	return client, nil
+}

--- a/pkg/tools/mcp.go
+++ b/pkg/tools/mcp.go
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/mcp"
+)
+
+// MCPInvoker defines the subset of the MCP client used by the tool wrapper.
+type MCPInvoker interface {
+	CallTool(ctx context.Context, name string, arguments map[string]any) (mcp.CallResult, error)
+}
+
+// MCPTool adapts an MCP server tool to the agent.Tool interface.
+type MCPTool struct {
+	client     MCPInvoker
+	remoteName string
+	name       string
+	desc       string
+
+	buildArgs func(string) map[string]any
+}
+
+// MCPToolOption customises the behaviour of the MCP tool wrapper.
+type MCPToolOption func(*MCPTool)
+
+// WithMCPDisplayName overrides the name reported to the coordinator. By
+// default the remote tool name is used.
+func WithMCPDisplayName(name string) MCPToolOption {
+	return func(t *MCPTool) {
+		if strings.TrimSpace(name) != "" {
+			t.name = name
+		}
+	}
+}
+
+// WithMCPArgumentBuilder overrides how input strings are converted into the
+// arguments payload sent to the MCP server. The default behaviour forwards the
+// string using the key "input".
+func WithMCPArgumentBuilder(fn func(string) map[string]any) MCPToolOption {
+	return func(t *MCPTool) {
+		if fn != nil {
+			t.buildArgs = fn
+		}
+	}
+}
+
+// NewMCPTool constructs a tool wrapper for the provided MCP tool definition.
+func NewMCPTool(client MCPInvoker, def mcp.ToolDefinition, opts ...MCPToolOption) *MCPTool {
+	tool := &MCPTool{
+		client:     client,
+		remoteName: def.Name,
+		name:       def.Name,
+		desc:       def.Description,
+		buildArgs: func(input string) map[string]any {
+			return map[string]any{"input": strings.TrimSpace(input)}
+		},
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt(tool)
+		}
+	}
+
+	return tool
+}
+
+// Name implements agent.Tool.
+func (t *MCPTool) Name() string {
+	if t == nil {
+		return ""
+	}
+	return t.name
+}
+
+// Description implements agent.Tool.
+func (t *MCPTool) Description() string {
+	if t == nil {
+		return ""
+	}
+	return t.desc
+}
+
+// Run invokes the remote MCP tool and returns the concatenated textual
+// response. JSON payloads fall back to their string representation when no text
+// content is present.
+func (t *MCPTool) Run(ctx context.Context, input string) (string, error) {
+	if t == nil || t.client == nil {
+		return "", fmt.Errorf("mcp tool is not initialised")
+	}
+
+	args := t.buildArgs(input)
+	result, err := t.client.CallTool(ctx, t.remoteName, args)
+	if err != nil {
+		return "", err
+	}
+
+	output := strings.TrimSpace(result.Text())
+	if output == "" {
+		output = strings.TrimSpace(result.JSON())
+	}
+	return output, nil
+}

--- a/pkg/tools/mcp_test.go
+++ b/pkg/tools/mcp_test.go
@@ -1,0 +1,93 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/mcp"
+)
+
+type fakeMCPClient struct {
+	responses map[string]mcp.CallResult
+	err       error
+}
+
+func (f *fakeMCPClient) CallTool(ctx context.Context, name string, args map[string]any) (mcp.CallResult, error) {
+	if f.err != nil {
+		return mcp.CallResult{}, f.err
+	}
+	res, ok := f.responses[name]
+	if !ok {
+		return mcp.CallResult{}, errors.New("unknown tool")
+	}
+	return res, nil
+}
+
+func TestMCPTool_RunText(t *testing.T) {
+	client := &fakeMCPClient{
+		responses: map[string]mcp.CallResult{
+			"echo": {Content: []mcp.Content{{Type: "text", Text: "hello"}}},
+		},
+	}
+
+	tool := NewMCPTool(client, mcp.ToolDefinition{Name: "echo", Description: "Echo"})
+	out, err := tool.Run(context.Background(), "ignored")
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if out != "hello" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestMCPTool_RunJSONFallback(t *testing.T) {
+	client := &fakeMCPClient{
+		responses: map[string]mcp.CallResult{
+			"json": {Content: []mcp.Content{{Type: "json", Data: []byte(`{"value":42}`)}}},
+		},
+	}
+
+	tool := NewMCPTool(client, mcp.ToolDefinition{Name: "json", Description: "JSON"})
+	out, err := tool.Run(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if out != "{\n  \"value\": 42\n}" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestMCPTool_ArgumentBuilder(t *testing.T) {
+	var captured map[string]any
+	client := &fakeMCPClient{
+		responses: map[string]mcp.CallResult{
+			"echo": {Content: []mcp.Content{{Type: "text", Text: "ok"}}},
+		},
+	}
+
+	tool := NewMCPTool(&capturingClient{MCPInvoker: client, capture: func(args map[string]any) {
+		captured = args
+	}}, mcp.ToolDefinition{Name: "echo"}, WithMCPArgumentBuilder(func(input string) map[string]any {
+		return map[string]any{"message": input}
+	}))
+
+	if _, err := tool.Run(context.Background(), "hi"); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if captured["message"] != "hi" {
+		t.Fatalf("argument builder not applied: %#v", captured)
+	}
+}
+
+type capturingClient struct {
+	MCPInvoker
+	capture func(map[string]any)
+}
+
+func (c *capturingClient) CallTool(ctx context.Context, name string, args map[string]any) (mcp.CallResult, error) {
+	if c.capture != nil {
+		c.capture(args)
+	}
+	return c.MCPInvoker.CallTool(ctx, name, args)
+}


### PR DESCRIPTION
## Summary
- add a lightweight Model Context Protocol client with stdio transport support and regression tests
- adapt MCP tools to the agent interface and allow the demo CLI to register remote tools via new flags
- document how to launch the CLI with an MCP server in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ecef211afc832287da2d46141c17d3