### PR TITLE
Refactor Go ADK tooling to structured specification

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -102,8 +102,8 @@ func main() {
 	}
 
 	fmt.Println("--- Agent Development Kit Demo ---")
-	fmt.Printf("Tools: %s\n", names(rt.Tools()))
-	fmt.Printf("Sub-agents: %s\n\n", names(rt.SubAgents()))
+	fmt.Printf("Tools: %s\n", toolNames(rt.Tools()))
+	fmt.Printf("Sub-agents: %s\n\n", subAgentNames(rt.SubAgents()))
 
 	type result struct {
 		idx      int
@@ -147,13 +147,24 @@ func main() {
 	fmt.Println("💾 All interactions flushed to long-term memory.")
 }
 
-func names[T interface{ Name() string }](items []T) string {
-	if len(items) == 0 {
+func toolNames(tools []agent.Tool) string {
+	if len(tools) == 0 {
 		return "<none>"
 	}
-	names := make([]string, len(items))
-	for i, item := range items {
-		names[i] = item.Name()
+	names := make([]string, len(tools))
+	for i, tool := range tools {
+		names[i] = tool.Spec().Name
+	}
+	return strings.Join(names, ", ")
+}
+
+func subAgentNames(subagents []agent.SubAgent) string {
+	if len(subagents) == 0 {
+		return "<none>"
+	}
+	names := make([]string, len(subagents))
+	for i, sa := range subagents {
+		names[i] = sa.Name()
 	}
 	return strings.Join(names, ", ")
 }

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -2,11 +2,30 @@ package agent
 
 import "context"
 
-// Tool is an executable capability the primary agent can call into.
+// ToolSpec describes how the agent should present a tool to the model.
+type ToolSpec struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	InputSchema map[string]any   `json:"input_schema"`
+	Examples    []map[string]any `json:"examples,omitempty"`
+}
+
+// ToolRequest captures an invocation request for a tool.
+type ToolRequest struct {
+	SessionID string
+	Arguments map[string]any
+}
+
+// ToolResponse represents the structured response returned by a tool.
+type ToolResponse struct {
+	Content  string
+	Metadata map[string]string
+}
+
+// Tool exposes structured metadata and an invocation handler.
 type Tool interface {
-	Name() string
-	Description() string
-	Run(ctx context.Context, input string) (string, error)
+	Spec() ToolSpec
+	Invoke(ctx context.Context, req ToolRequest) (ToolResponse, error)
 }
 
 // SubAgent represents a specialist agent that can be delegated work.

--- a/pkg/tools/calculator.go
+++ b/pkg/tools/calculator.go
@@ -6,29 +6,48 @@ import (
 	"math"
 	"strconv"
 	"strings"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/agent"
 )
 
 // CalculatorTool evaluates basic arithmetic expressions in the form "a op b".
 type CalculatorTool struct{}
 
-func (c *CalculatorTool) Name() string { return "calculator" }
-func (c *CalculatorTool) Description() string {
-	return "Evaluates simple math expressions such as '2 + 2' or '5 * 3'."
+func (c *CalculatorTool) Spec() agent.ToolSpec {
+	return agent.ToolSpec{
+		Name:        "calculator",
+		Description: "Evaluates simple math expressions such as '2 + 2' or '5 * 3'.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"expression": map[string]any{
+					"type":        "string",
+					"description": "Expression in the form '<number> <operator> <number>'.",
+				},
+			},
+			"required": []any{"expression"},
+		},
+	}
 }
 
-func (c *CalculatorTool) Run(_ context.Context, input string) (string, error) {
-	fields := strings.Fields(input)
+func (c *CalculatorTool) Invoke(_ context.Context, req agent.ToolRequest) (agent.ToolResponse, error) {
+	exprRaw, ok := req.Arguments["expression"]
+	if !ok {
+		return agent.ToolResponse{}, fmt.Errorf("missing 'expression' argument")
+	}
+	expression := strings.TrimSpace(fmt.Sprint(exprRaw))
+	fields := strings.Fields(expression)
 	if len(fields) != 3 {
-		return "", fmt.Errorf("expected format '<number> <op> <number>'")
+		return agent.ToolResponse{}, fmt.Errorf("expected format '<number> <op> <number>'")
 	}
 
 	left, err := strconv.ParseFloat(fields[0], 64)
 	if err != nil {
-		return "", fmt.Errorf("invalid left operand: %w", err)
+		return agent.ToolResponse{}, fmt.Errorf("invalid left operand: %w", err)
 	}
 	right, err := strconv.ParseFloat(fields[2], 64)
 	if err != nil {
-		return "", fmt.Errorf("invalid right operand: %w", err)
+		return agent.ToolResponse{}, fmt.Errorf("invalid right operand: %w", err)
 	}
 
 	var result float64
@@ -41,12 +60,12 @@ func (c *CalculatorTool) Run(_ context.Context, input string) (string, error) {
 		result = left * right
 	case "/":
 		if math.Abs(right) < 1e-12 {
-			return "", fmt.Errorf("division by zero")
+			return agent.ToolResponse{}, fmt.Errorf("division by zero")
 		}
 		result = left / right
 	default:
-		return "", fmt.Errorf("unsupported operator %q", fields[1])
+		return agent.ToolResponse{}, fmt.Errorf("unsupported operator %q", fields[1])
 	}
 
-	return strconv.FormatFloat(result, 'f', -1, 64), nil
+	return agent.ToolResponse{Content: strconv.FormatFloat(result, 'f', -1, 64)}, nil
 }

--- a/pkg/tools/echo.go
+++ b/pkg/tools/echo.go
@@ -2,15 +2,36 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"strings"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/agent"
 )
 
 // EchoTool repeats the provided input. Useful for testing tool wiring.
 type EchoTool struct{}
 
-func (e *EchoTool) Name() string        { return "echo" }
-func (e *EchoTool) Description() string { return "Echoes the provided text back to the caller." }
+func (e *EchoTool) Spec() agent.ToolSpec {
+	return agent.ToolSpec{
+		Name:        "echo",
+		Description: "Echoes the provided text back to the caller.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"input": map[string]any{
+					"type":        "string",
+					"description": "Text to echo back.",
+				},
+			},
+			"required": []any{"input"},
+		},
+	}
+}
 
-func (e *EchoTool) Run(_ context.Context, input string) (string, error) {
-	return strings.TrimSpace(input), nil
+func (e *EchoTool) Invoke(_ context.Context, req agent.ToolRequest) (agent.ToolResponse, error) {
+	raw := req.Arguments["input"]
+	if raw == nil {
+		return agent.ToolResponse{Content: ""}, nil
+	}
+	return agent.ToolResponse{Content: strings.TrimSpace(fmt.Sprint(raw))}, nil
 }

--- a/pkg/tools/time.go
+++ b/pkg/tools/time.go
@@ -3,14 +3,24 @@ package tools
 import (
 	"context"
 	"time"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/agent"
 )
 
 // TimeTool reports the current UTC time in RFC3339 format.
 type TimeTool struct{}
 
-func (t *TimeTool) Name() string        { return "time" }
-func (t *TimeTool) Description() string { return "Returns the current UTC time." }
+func (t *TimeTool) Spec() agent.ToolSpec {
+	return agent.ToolSpec{
+		Name:        "time",
+		Description: "Returns the current UTC time.",
+		InputSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+	}
+}
 
-func (t *TimeTool) Run(_ context.Context, _ string) (string, error) {
-	return time.Now().UTC().Format(time.RFC3339), nil
+func (t *TimeTool) Invoke(_ context.Context, _ agent.ToolRequest) (agent.ToolResponse, error) {
+	return agent.ToolResponse{Content: time.Now().UTC().Format(time.RFC3339)}, nil
 }

--- a/pkg/tools/tools_test.go
+++ b/pkg/tools/tools_test.go
@@ -4,47 +4,49 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/agent"
 )
 
 func TestEchoTool(t *testing.T) {
 	tool := &EchoTool{}
-	out, err := tool.Run(context.Background(), "  hello world  ")
+	out, err := tool.Invoke(context.Background(), agent.ToolRequest{Arguments: map[string]any{"input": "  hello world  "}})
 	if err != nil {
-		t.Fatalf("Run returned error: %v", err)
+		t.Fatalf("Invoke returned error: %v", err)
 	}
-	if out != "hello world" {
-		t.Fatalf("unexpected output: %q", out)
+	if out.Content != "hello world" {
+		t.Fatalf("unexpected output: %q", out.Content)
 	}
 }
 
 func TestCalculatorTool(t *testing.T) {
 	tool := &CalculatorTool{}
-	out, err := tool.Run(context.Background(), "21 / 3")
+	out, err := tool.Invoke(context.Background(), agent.ToolRequest{Arguments: map[string]any{"expression": "21 / 3"}})
 	if err != nil {
-		t.Fatalf("Run returned error: %v", err)
+		t.Fatalf("Invoke returned error: %v", err)
 	}
-	if out != "7" {
-		t.Fatalf("unexpected calculator result: %q", out)
+	if out.Content != "7" {
+		t.Fatalf("unexpected calculator result: %q", out.Content)
 	}
 }
 
 func TestCalculatorToolErrors(t *testing.T) {
 	tool := &CalculatorTool{}
-	if _, err := tool.Run(context.Background(), "bad input"); err == nil {
+	if _, err := tool.Invoke(context.Background(), agent.ToolRequest{Arguments: map[string]any{"expression": "bad input"}}); err == nil {
 		t.Fatalf("expected format error")
 	}
-	if _, err := tool.Run(context.Background(), "1 / 0"); err == nil {
+	if _, err := tool.Invoke(context.Background(), agent.ToolRequest{Arguments: map[string]any{"expression": "1 / 0"}}); err == nil {
 		t.Fatalf("expected division by zero error")
 	}
 }
 
 func TestTimeTool(t *testing.T) {
 	tool := &TimeTool{}
-	out, err := tool.Run(context.Background(), "")
+	out, err := tool.Invoke(context.Background(), agent.ToolRequest{Arguments: map[string]any{}})
 	if err != nil {
-		t.Fatalf("Run returned error: %v", err)
+		t.Fatalf("Invoke returned error: %v", err)
 	}
-	if _, err := time.Parse(time.RFC3339, out); err != nil {
-		t.Fatalf("expected RFC3339 output, got %q: %v", out, err)
+	if _, err := time.Parse(time.RFC3339, out.Content); err != nil {
+		t.Fatalf("expected RFC3339 output, got %q: %v", out.Content, err)
 	}
 }


### PR DESCRIPTION
## Summary
- introduce structured tool specifications and invocation requests mirroring the Python ADK contract
- update the coordinator agent to advertise tool schemas and parse JSON arguments before invoking tools
- port bundled tools, CLI demo, and tests to the new structured interface

## Testing
- go test ./... *(fails: hangs waiting for external Vertex AI client initialisation in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68edfc45e9b48322af69a38e530eb8a2