### PR TITLE
Refactor agent runtime around ADK-style registries and sessions

### DIFF
--- a/docs/ADK_MIGRATION.md
+++ b/docs/ADK_MIGRATION.md
@@ -1,0 +1,46 @@
+# ADK Alignment Migration Guide
+
+The Google Agent Development Kit (ADK) documentation was not accessible from the execution
+environment. The refactor below follows the published high-level concepts (coordinator agents,
+tool registries, sub-agent directories, and deterministic session management) based on prior
+knowledge of ADK terminology. Any divergences should be reconciled once the official guidance
+can be reviewed.
+
+## What Changed
+
+1. **Tool and Sub-agent registries**
+   - `pkg/agent` now exposes `ToolCatalog` and `SubAgentDirectory` interfaces with default
+     in-memory implementations.
+   - The coordinator agent consumes these abstractions instead of managing raw maps.
+   - Custom registries can be injected via `agent.Options` to integrate with external discovery
+     services.
+
+2. **Runtime session manager**
+   - `pkg/runtime` introduced a dedicated session manager that keeps the active session set
+     threadsafe, deterministic, and ADK-aligned.
+   - Runtime helpers (`NewSession`, `GetSession`, `ActiveSessions`, `RemoveSession`) proxy through
+     the manager.
+
+3. **Public accessors**
+   - `agent.Agent` now publishes `Tools()`, `ToolSpecs()`, and `SubAgents()` accessors so the
+     runtime can reflect the registered capabilities without touching internals.
+
+4. **Documentation updates**
+   - The README highlights the new abstractions and how they map to ADK nomenclature.
+
+## Migration Steps
+
+Existing callers can continue to pass `Options{Tools: ..., SubAgents: ...}`. For a gradual
+migration:
+
+1. Swap any direct access to `agent.Agent` internals (e.g. `agent.tools`) with the new accessor
+   methods.
+2. When you need custom discovery logic, implement the `ToolCatalog`/`SubAgentDirectory`
+   interfaces and supply them through `agent.Options` alongside (or instead of) the legacy slices.
+3. If you relied on mutating `runtime.Tools()` slices, switch to calling `rt.Agent().Tools()` and
+   treat the result as read-only; every call returns a defensive copy.
+4. For session lifecycle integrations, prefer `runtime.ActiveSessions()` over direct map access
+   and use `runtime.RemoveSession()` to prune idle sessions.
+
+> **TODO:** Once the official ADK specification is available, audit the naming and lifecycle hooks
+> introduced here and adjust any mismatches.

--- a/pkg/agent/catalog.go
+++ b/pkg/agent/catalog.go
@@ -1,0 +1,148 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// StaticToolCatalog is the default in-memory implementation of ToolCatalog used by the runtime.
+type StaticToolCatalog struct {
+	mu    sync.RWMutex
+	tools map[string]Tool
+	specs map[string]ToolSpec
+	order []string
+}
+
+// NewStaticToolCatalog constructs a catalog seeded with the provided tools.
+func NewStaticToolCatalog(tools []Tool) *StaticToolCatalog {
+	catalog := &StaticToolCatalog{
+		tools: make(map[string]Tool),
+		specs: make(map[string]ToolSpec),
+	}
+	for _, tool := range tools {
+		_ = catalog.Register(tool) // skip invalid entries silently to match legacy behaviour
+	}
+	return catalog
+}
+
+// Register adds a tool to the catalog using a lower-cased key. Duplicate names return an error.
+func (c *StaticToolCatalog) Register(tool Tool) error {
+	if tool == nil {
+		return fmt.Errorf("tool is nil")
+	}
+	spec := tool.Spec()
+	key := strings.ToLower(strings.TrimSpace(spec.Name))
+	if key == "" {
+		return fmt.Errorf("tool name is empty")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.tools[key]; exists {
+		return fmt.Errorf("tool %s already registered", spec.Name)
+	}
+	c.tools[key] = tool
+	c.specs[key] = spec
+	c.order = append(c.order, key)
+	return nil
+}
+
+// Lookup returns the tool and its specification if present.
+func (c *StaticToolCatalog) Lookup(name string) (Tool, ToolSpec, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	key := strings.ToLower(strings.TrimSpace(name))
+	tool, ok := c.tools[key]
+	if !ok {
+		return nil, ToolSpec{}, false
+	}
+	return tool, c.specs[key], true
+}
+
+// Specs returns a snapshot of the tool specifications in registration order.
+func (c *StaticToolCatalog) Specs() []ToolSpec {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	specs := make([]ToolSpec, 0, len(c.order))
+	for _, key := range c.order {
+		specs = append(specs, c.specs[key])
+	}
+	return specs
+}
+
+// Tools returns the registered tools in order.
+func (c *StaticToolCatalog) Tools() []Tool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	tools := make([]Tool, 0, len(c.order))
+	for _, key := range c.order {
+		tools = append(tools, c.tools[key])
+	}
+	return tools
+}
+
+// StaticSubAgentDirectory is the default SubAgentDirectory implementation.
+type StaticSubAgentDirectory struct {
+	mu        sync.RWMutex
+	subagents map[string]SubAgent
+	order     []string
+}
+
+// NewStaticSubAgentDirectory constructs a directory from the provided sub-agents.
+func NewStaticSubAgentDirectory(subagents []SubAgent) *StaticSubAgentDirectory {
+	dir := &StaticSubAgentDirectory{
+		subagents: make(map[string]SubAgent),
+	}
+	for _, sa := range subagents {
+		_ = dir.Register(sa)
+	}
+	return dir
+}
+
+// Register adds a sub-agent to the directory. Duplicate names return an error.
+func (d *StaticSubAgentDirectory) Register(subAgent SubAgent) error {
+	if subAgent == nil {
+		return fmt.Errorf("sub-agent is nil")
+	}
+	key := strings.ToLower(strings.TrimSpace(subAgent.Name()))
+	if key == "" {
+		return fmt.Errorf("sub-agent name is empty")
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, exists := d.subagents[key]; exists {
+		return fmt.Errorf("sub-agent %s already registered", subAgent.Name())
+	}
+	d.subagents[key] = subAgent
+	d.order = append(d.order, key)
+	return nil
+}
+
+// Lookup retrieves a sub-agent by name.
+func (d *StaticSubAgentDirectory) Lookup(name string) (SubAgent, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	key := strings.ToLower(strings.TrimSpace(name))
+	sa, ok := d.subagents[key]
+	return sa, ok
+}
+
+// All returns the registered sub-agents in registration order.
+func (d *StaticSubAgentDirectory) All() []SubAgent {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	subagents := make([]SubAgent, 0, len(d.order))
+	for _, key := range d.order {
+		subagents = append(subagents, d.subagents[key])
+	}
+	return subagents
+}

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -28,9 +28,24 @@ type Tool interface {
 	Invoke(ctx context.Context, req ToolRequest) (ToolResponse, error)
 }
 
+// ToolCatalog maintains an ordered set of tools and provides lookup by name.
+type ToolCatalog interface {
+	Register(tool Tool) error
+	Lookup(name string) (Tool, ToolSpec, bool)
+	Specs() []ToolSpec
+	Tools() []Tool
+}
+
 // SubAgent represents a specialist agent that can be delegated work.
 type SubAgent interface {
 	Name() string
 	Description() string
 	Run(ctx context.Context, input string) (string, error)
+}
+
+// SubAgentDirectory stores sub-agents by name while preserving insertion order.
+type SubAgentDirectory interface {
+	Register(subAgent SubAgent) error
+	Lookup(name string) (SubAgent, bool)
+	All() []SubAgent
 }

--- a/pkg/runtime/session_manager.go
+++ b/pkg/runtime/session_manager.go
@@ -1,0 +1,66 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+type sessionManager struct {
+	runtime *Runtime
+
+	counter  atomic.Uint64
+	mu       sync.RWMutex
+	sessions map[string]*Session
+}
+
+func newSessionManager(rt *Runtime) *sessionManager {
+	return &sessionManager{
+		runtime:  rt,
+		sessions: make(map[string]*Session),
+	}
+}
+
+func (m *sessionManager) newSession(id string) *Session {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		id = fmt.Sprintf("session-%d", m.counter.Add(1))
+	}
+	session := &Session{runtime: m.runtime, id: id}
+
+	m.mu.Lock()
+	m.sessions[id] = session
+	m.mu.Unlock()
+
+	return session
+}
+
+func (m *sessionManager) getSession(id string) (*Session, error) {
+	m.mu.RLock()
+	session, ok := m.sessions[id]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("session %s not found", id)
+	}
+	return session, nil
+}
+
+func (m *sessionManager) removeSession(id string) {
+	m.mu.Lock()
+	delete(m.sessions, id)
+	m.mu.Unlock()
+}
+
+func (m *sessionManager) activeIDs() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	ids := make([]string, 0, len(m.sessions))
+	for id := range m.sessions {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}


### PR DESCRIPTION
## Summary
- introduce `ToolCatalog` and `SubAgentDirectory` abstractions with default in-memory implementations to match ADK terminology
- refactor the runtime to use a dedicated session manager while exposing catalog-backed tool/sub-agent listings
- update the README and add an ADK migration guide documenting the offline assumption that guided the refactor

## Testing
- `go test ./...` *(fails: module downloads require external network access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee121588648322bd8f27e9f99dc907