### PR TITLE
fix: enforce importance-first retrieval ordering

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -124,12 +125,25 @@ func startServer(addr string) {
 
 func main() {
 	var (
-		dsn         = flag.String("dsn", "postgres://admin:admin@localhost:5432/ragdb?sslmode=disable", "Postgres DSN")
-		schemaPath  = flag.String("schema", "schema.sql", "Path to schema file")
-		modelName   = flag.String("model", "gemini-2.5-pro", "Gemini model ID")
-		sessionID   = flag.String("session", "", "Optional fixed session ID (reuse memory)")
-		promptLimit = flag.Int("context", 6, "Number of conversation turns to send to model")
-		windowSize  = flag.Int("window", 8, "Short-term memory window size")
+		dsn                    = flag.String("dsn", "postgres://admin:admin@localhost:5432/ragdb?sslmode=disable", "Postgres DSN")
+		schemaPath             = flag.String("schema", "schema.sql", "Path to schema file")
+		modelName              = flag.String("model", "gemini-2.5-pro", "Gemini model ID")
+		sessionID              = flag.String("session", "", "Optional fixed session ID (reuse memory)")
+		promptLimit            = flag.Int("context", 6, "Number of conversation turns to send to model")
+		windowSize             = flag.Int("window", 8, "Short-term memory window size")
+		memorySimWeight        = flag.Float64("memory-sim-weight", 0.55, "Similarity weight for memory retrieval scoring")
+		memoryImportanceWeight = flag.Float64("memory-importance-weight", 0.25, "Importance weight for memory retrieval scoring")
+		memoryRecencyWeight    = flag.Float64("memory-recency-weight", 0.15, "Recency weight for memory retrieval scoring")
+		memorySourceWeight     = flag.Float64("memory-source-weight", 0.05, "Source weight for memory retrieval scoring")
+		memoryLambda           = flag.Float64("memory-mmr-lambda", 0.7, "Lambda parameter for maximal marginal relevance")
+		memoryHalfLife         = flag.Duration("memory-half-life", 72*time.Hour, "Half-life used for recency decay")
+		memoryClusterSim       = flag.Float64("memory-cluster-sim", 0.83, "Similarity threshold for cluster summaries")
+		memoryDrift            = flag.Float64("memory-drift-threshold", 0.90, "Cosine similarity threshold triggering re-embedding")
+		memoryDuplicate        = flag.Float64("memory-duplicate-sim", 0.97, "Similarity threshold for deduplication")
+		memoryTTL              = flag.Duration("memory-ttl", 720*time.Hour, "Time-to-live for stored memories")
+		memoryMaxSize          = flag.Int("memory-max-size", 200000, "Maximum number of memories to retain before pruning")
+		memorySourceBoost      = flag.String("memory-source-boost", "", "Comma separated source=weight overrides (e.g. pagerduty=1.0,slack=0.6)")
+		memoryDisableSummaries = flag.Bool("memory-disable-summaries", false, "Disable cluster-based summarisation")
 	)
 	flag.Parse()
 	go startServer(":8080")
@@ -154,6 +168,28 @@ func main() {
 		log.Fatalf("❌ failed to ensure schema: %v", err)
 	}
 
+	memoryOpts := memory.Options{
+		Weights: memory.ScoreWeights{
+			Similarity: *memorySimWeight,
+			Importance: *memoryImportanceWeight,
+			Recency:    *memoryRecencyWeight,
+			Source:     *memorySourceWeight,
+		},
+		LambdaMMR:           *memoryLambda,
+		HalfLife:            *memoryHalfLife,
+		ClusterSimilarity:   *memoryClusterSim,
+		DriftThreshold:      *memoryDrift,
+		DuplicateSimilarity: *memoryDuplicate,
+		TTL:                 *memoryTTL,
+		MaxSize:             *memoryMaxSize,
+		SourceBoost:         parseSourceBoostFlag(*memorySourceBoost),
+		EnableSummaries:     !*memoryDisableSummaries,
+		DisableSummaries:    *memoryDisableSummaries,
+	}
+
+	engineLogger := log.New(os.Stderr, "memory-engine: ", log.LstdFlags)
+	memoryEngine := memory.NewEngine(bank.Store, memoryOpts).WithLogger(engineLogger)
+
 	// --- 🧩 2. Create LLMs ---
 	researcherModel, err := models.NewGeminiLLM(ctx, *modelName, "Research summary:")
 	if err != nil {
@@ -174,7 +210,7 @@ func main() {
 			return bank, nil // reuse persistent connection
 		},
 		SessionMemoryBuilder: func(bank *memory.MemoryBank, window int) *memory.SessionMemory {
-			return memory.NewSessionMemory(bank, window)
+			return memory.NewSessionMemory(bank, window).WithEngine(memoryEngine)
 		},
 		Tools: []agent.Tool{
 			&tools.EchoTool{},
@@ -272,6 +308,31 @@ func main() {
 	}
 
 	fmt.Println("💾 All interactions flushed to long-term memory.")
+}
+
+func parseSourceBoostFlag(raw string) map[string]float64 {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	boosts := make(map[string]float64)
+	pairs := strings.Split(raw, ",")
+	for _, pair := range pairs {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		value, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			continue
+		}
+		boosts[key] = value
+	}
+	if len(boosts) == 0 {
+		return nil
+	}
+	return boosts
 }
 
 func toolNames(tools []agent.Tool) string {

--- a/pkg/memory/engine.go
+++ b/pkg/memory/engine.go
@@ -1,0 +1,527 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Engine coordinates scoring, clustering, pruning and retrieval of memories.
+type Engine struct {
+	store      VectorStore
+	opts       Options
+	embedder   Embedder
+	summarizer Summarizer
+	metrics    *Metrics
+	logger     *log.Logger
+	clock      func() time.Time
+	mu         sync.Mutex
+}
+
+// NewEngine constructs an advanced memory engine on top of a VectorStore implementation.
+func NewEngine(store VectorStore, opts Options) *Engine {
+	opts = opts.withDefaults()
+	engine := &Engine{
+		store:      store,
+		opts:       opts,
+		embedder:   AutoEmbedder(),
+		summarizer: HeuristicSummarizer{},
+		metrics:    &Metrics{},
+		logger:     log.New(os.Stderr, "memory-engine: ", log.LstdFlags),
+		clock:      opts.Clock,
+	}
+	if engine.clock == nil {
+		engine.clock = time.Now
+	}
+	return engine
+}
+
+// WithEmbedder overrides the default embedder.
+func (e *Engine) WithEmbedder(embedder Embedder) *Engine {
+	if embedder != nil {
+		e.embedder = embedder
+	}
+	return e
+}
+
+// WithSummarizer overrides the default cluster summarizer.
+func (e *Engine) WithSummarizer(s Summarizer) *Engine {
+	if s != nil {
+		e.summarizer = s
+	}
+	return e
+}
+
+// WithLogger overrides the default logger.
+func (e *Engine) WithLogger(logger *log.Logger) *Engine {
+	if logger != nil {
+		e.logger = logger
+	}
+	return e
+}
+
+func (e *Engine) logf(format string, args ...any) {
+	if e.logger != nil {
+		e.logger.Printf(format, args...)
+	}
+}
+
+// MetricsSnapshot returns a copy of the runtime counters.
+func (e *Engine) MetricsSnapshot() MetricsSnapshot {
+	return e.metrics.Snapshot()
+}
+
+// Store embeds, scores and persists a new memory.
+func (e *Engine) Store(ctx context.Context, sessionID, content string, metadata map[string]any) (MemoryRecord, error) {
+	if e.store == nil {
+		return MemoryRecord{}, errors.New("memory engine has no store")
+	}
+	embedding, err := e.embed(ctx, content)
+	if err != nil {
+		return MemoryRecord{}, fmt.Errorf("embed content: %w", err)
+	}
+	now := e.clock().UTC()
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	if _, ok := metadata["source"]; !ok {
+		metadata["source"] = "default"
+	}
+	importance := importanceScore(content, metadata)
+	metadata["importance"] = importance
+	// Deduplication based on cosine similarity.
+	candidates, err := e.store.SearchMemory(ctx, embedding, 5)
+	if err != nil {
+		return MemoryRecord{}, err
+	}
+	for _, cand := range candidates {
+		sim := cosineSimilarity(embedding, cand.Embedding)
+		if sim >= e.opts.DuplicateSimilarity {
+			e.metrics.IncDeduplicated()
+			e.logf("deduplicated memory against existing id=%d (sim=%.2f)", cand.ID, sim)
+			return cand, nil
+		}
+	}
+	// Cluster summary for the new record.
+	newRecord := MemoryRecord{
+		SessionID:    sessionID,
+		Content:      content,
+		Embedding:    embedding,
+		Importance:   importance,
+		Source:       stringFromAny(metadata["source"]),
+		CreatedAt:    now,
+		LastEmbedded: now,
+	}
+	if e.opts.EnableSummaries {
+		summary, sumErr := e.clusterSummary(ctx, append(candidates, newRecord), newRecord)
+		if sumErr != nil {
+			e.logf("failed to summarize cluster: %v", sumErr)
+		} else {
+			metadata["summary"] = summary
+		}
+	}
+	metadata["last_embedded"] = now.UTC().Format(time.RFC3339Nano)
+	if err := e.store.StoreMemory(ctx, sessionID, content, metadata, embedding); err != nil {
+		return MemoryRecord{}, err
+	}
+	stored := newRecord
+	if results, err := e.store.SearchMemory(ctx, embedding, 1); err == nil && len(results) > 0 {
+		stored = results[0]
+	}
+	e.metrics.IncStored()
+	e.logf("stored memory for session=%s importance=%.2f", sessionID, importance)
+	if err := e.Prune(ctx); err != nil {
+		e.logf("prune error: %v", err)
+	}
+	stored.Metadata = stringFromAny(metadata)
+	stored.Summary = stringFromAny(metadata["summary"])
+	stored.Importance = importance
+	return stored, nil
+}
+
+// Retrieve performs weighted retrieval with MMR diversification and optional re-embedding.
+func (e *Engine) Retrieve(ctx context.Context, query string, limit int) ([]MemoryRecord, error) {
+	if e.store == nil {
+		return nil, errors.New("memory engine has no store")
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	embedding, err := e.embed(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("embed query: %w", err)
+	}
+	candidates, err := e.store.SearchMemory(ctx, embedding, limit*4)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	weights := e.opts.normalizedWeights()
+	now := e.clock().UTC()
+	for i := range candidates {
+		rec := &candidates[i]
+		if rec.Importance == 0 {
+			rec.Importance = importanceScore(rec.Content, decodeMetadata(rec.Metadata))
+		}
+		rec.Score = cosineSimilarity(embedding, rec.Embedding)
+		recency := recencyScore(now.Sub(rec.CreatedAt), e.opts.HalfLife)
+		sourceScore := e.sourceScore(rec.Source)
+		rec.WeightedScore = weights.Similarity*rec.Score + weights.Importance*rec.Importance + weights.Recency*recency + weights.Source*sourceScore
+	}
+	selected := mmrSelect(candidates, embedding, limit, e.opts.LambdaMMR)
+	if e.opts.EnableSummaries {
+		if err := e.populateSummaries(ctx, selected); err != nil {
+			e.logf("populate summaries: %v", err)
+		}
+	}
+	if err := e.reembedOnDrift(ctx, selected); err != nil {
+		e.logf("reembed drift: %v", err)
+	}
+	e.metrics.IncRetrieved(len(selected))
+	sort.SliceStable(selected, func(i, j int) bool {
+		if selected[i].Importance != selected[j].Importance {
+			return selected[i].Importance > selected[j].Importance
+		}
+		if selected[i].WeightedScore != selected[j].WeightedScore {
+			return selected[i].WeightedScore > selected[j].WeightedScore
+		}
+		if selected[i].Score != selected[j].Score {
+			return selected[i].Score > selected[j].Score
+		}
+		return selected[i].CreatedAt.After(selected[j].CreatedAt)
+	})
+	return selected, nil
+}
+
+// Prune applies TTL, size and deduplication policies.
+func (e *Engine) Prune(ctx context.Context) error {
+	if e.store == nil {
+		return nil
+	}
+	now := e.clock().UTC()
+	var toDelete []int64
+	seenHashes := make(map[string]int64)
+	err := e.store.Iterate(ctx, func(rec MemoryRecord) bool {
+		if !rec.CreatedAt.IsZero() && now.Sub(rec.CreatedAt) > e.opts.TTL {
+			toDelete = append(toDelete, rec.ID)
+			return true
+		}
+		hash := strings.ToLower(strings.TrimSpace(rec.Content))
+		if existing, ok := seenHashes[hash]; ok {
+			toDelete = append(toDelete, rec.ID)
+			e.metrics.IncDeduplicated()
+			e.logf("prune dedupe: dropping id=%d duplicate of %d", rec.ID, existing)
+			return true
+		}
+		seenHashes[hash] = rec.ID
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	if len(toDelete) > 0 {
+		if err := e.store.DeleteMemory(ctx, toDelete); err != nil {
+			return err
+		}
+		e.metrics.IncPruned(len(toDelete))
+	}
+	count, err := e.store.Count(ctx)
+	if err != nil {
+		return err
+	}
+	if count <= e.opts.MaxSize {
+		return nil
+	}
+	overflow := count - e.opts.MaxSize
+	var scored []struct {
+		id    int64
+		score float64
+	}
+	err = e.store.Iterate(ctx, func(rec MemoryRecord) bool {
+		ageHours := now.Sub(rec.CreatedAt).Hours() + 1
+		importance := rec.Importance
+		if importance == 0 {
+			importance = importanceScore(rec.Content, decodeMetadata(rec.Metadata))
+		}
+		pruneScore := ageHours * (1 - importance)
+		scored = append(scored, struct {
+			id    int64
+			score float64
+		}{id: rec.ID, score: pruneScore})
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	sort.Slice(scored, func(i, j int) bool { return scored[i].score > scored[j].score })
+	if overflow > len(scored) {
+		overflow = len(scored)
+	}
+	var evict []int64
+	for i := 0; i < overflow; i++ {
+		evict = append(evict, scored[i].id)
+	}
+	if len(evict) > 0 {
+		if err := e.store.DeleteMemory(ctx, evict); err != nil {
+			return err
+		}
+		e.metrics.IncPruned(len(evict))
+	}
+	return nil
+}
+
+func (e *Engine) embed(ctx context.Context, text string) ([]float32, error) {
+	if e.embedder == nil {
+		e.embedder = AutoEmbedder()
+	}
+	vec, err := e.embedder.Embed(ctx, text)
+	if err != nil || len(vec) == 0 {
+		return DummyEmbedding(text), nil
+	}
+	return vec, nil
+}
+
+func (e *Engine) reembedOnDrift(ctx context.Context, records []MemoryRecord) error {
+	for _, rec := range records {
+		if rec.ID == 0 {
+			continue
+		}
+		age := e.clock().UTC().Sub(rec.LastEmbedded)
+		if age < e.opts.HalfLife && rec.LastEmbedded.After(time.Time{}) {
+			continue
+		}
+		vec, err := e.embed(ctx, rec.Content)
+		if err != nil {
+			return err
+		}
+		sim := cosineSimilarity(vec, rec.Embedding)
+		if sim >= e.opts.DriftThreshold {
+			continue
+		}
+		if err := e.store.UpdateEmbedding(ctx, rec.ID, vec, e.clock().UTC()); err != nil {
+			return err
+		}
+		e.metrics.IncReembedded()
+	}
+	return nil
+}
+
+func (e *Engine) populateSummaries(ctx context.Context, records []MemoryRecord) error {
+	if e.summarizer == nil || !e.opts.EnableSummaries {
+		return nil
+	}
+	clusters := clusterRecords(records, e.opts.ClusterSimilarity)
+	for _, cluster := range clusters {
+		summary, err := e.summarizer.Summarize(ctx, cluster)
+		if err != nil {
+			return err
+		}
+		e.metrics.IncClustersSummarized()
+		for i := range cluster {
+			for j := range records {
+				if records[j].ID == cluster[i].ID {
+					records[j].Summary = summary
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (e *Engine) clusterSummary(ctx context.Context, records []MemoryRecord, target MemoryRecord) (string, error) {
+	clusters := clusterRecords(records, e.opts.ClusterSimilarity)
+	for _, cluster := range clusters {
+		for _, rec := range cluster {
+			if rec.ID == target.ID || (rec.ID == 0 && rec.Content == target.Content) {
+				if e.summarizer == nil {
+					return "", nil
+				}
+				return e.summarizer.Summarize(ctx, cluster)
+			}
+		}
+	}
+	return "", nil
+}
+
+func (e *Engine) sourceScore(source string) float64 {
+	if source == "" {
+		source = "default"
+	}
+	if e.opts.SourceBoost == nil {
+		return 1
+	}
+	if val, ok := e.opts.SourceBoost[strings.ToLower(source)]; ok {
+		return clamp(val, 0, 1)
+	}
+	if val, ok := e.opts.SourceBoost["default"]; ok {
+		return clamp(val, 0, 1)
+	}
+	return 1
+}
+
+func recencyScore(age time.Duration, halfLife time.Duration) float64 {
+	if halfLife <= 0 {
+		return 1
+	}
+	decay := math.Pow(0.5, age.Seconds()/(halfLife.Seconds()))
+	if decay < 0 {
+		return 0
+	}
+	return decay
+}
+
+func importanceScore(content string, metadata map[string]any) float64 {
+	if val := floatFromAny(metadata["importance"]); val > 0 {
+		return clamp(val, 0, 1)
+	}
+	tokens := strings.Fields(strings.ToLower(content))
+	lengthScore := math.Min(float64(len(tokens))/60.0, 1.0)
+	keywordBoost := 0.0
+	urgentKeywords := []string{"urgent", "critical", "deadline", "important", "alert", "error"}
+	for _, kw := range urgentKeywords {
+		if strings.Contains(strings.ToLower(content), kw) {
+			keywordBoost += 0.1
+		}
+	}
+	if keywordBoost > 0.5 {
+		keywordBoost = 0.5
+	}
+	return clamp(lengthScore+keywordBoost, 0, 1)
+}
+
+func mmrSelect(records []MemoryRecord, query []float32, limit int, lambda float64) []MemoryRecord {
+	if limit >= len(records) {
+		out := make([]MemoryRecord, len(records))
+		copy(out, records)
+		return out
+	}
+	remaining := make([]MemoryRecord, len(records))
+	copy(remaining, records)
+	selected := make([]MemoryRecord, 0, limit)
+	for len(selected) < limit && len(remaining) > 0 {
+		bestIdx := 0
+		bestScore := math.Inf(-1)
+		for i, cand := range remaining {
+			simToQuery := cosineSimilarity(query, cand.Embedding)
+			var maxSim float64
+			for _, sel := range selected {
+				if sim := cosineSimilarity(cand.Embedding, sel.Embedding); sim > maxSim {
+					maxSim = sim
+				}
+			}
+			score := lambda*cand.WeightedScore + (1-lambda)*simToQuery - (1-lambda)*maxSim
+			if score > bestScore {
+				bestScore = score
+				bestIdx = i
+			}
+		}
+		selected = append(selected, remaining[bestIdx])
+		remaining = append(remaining[:bestIdx], remaining[bestIdx+1:]...)
+	}
+	return selected
+}
+
+func clusterRecords(records []MemoryRecord, threshold float64) [][]MemoryRecord {
+	if threshold <= 0 {
+		threshold = 0.8
+	}
+	type cluster struct {
+		centroid []float64
+		records  []MemoryRecord
+	}
+	var clusters []cluster
+	for _, rec := range records {
+		placed := false
+		for i := range clusters {
+			sim := cosineSimilarity(rec.Embedding, float32Slice(clusters[i].centroid))
+			if sim >= threshold {
+				clusters[i].records = append(clusters[i].records, rec)
+				clusters[i].centroid = updateCentroid(clusters[i].centroid, rec.Embedding)
+				placed = true
+				break
+			}
+		}
+		if !placed {
+			clusters = append(clusters, cluster{
+				centroid: float32To64(rec.Embedding),
+				records:  []MemoryRecord{rec},
+			})
+		}
+	}
+	result := make([][]MemoryRecord, len(clusters))
+	for i, cl := range clusters {
+		result[i] = cl.records
+	}
+	return result
+}
+
+func updateCentroid(current []float64, vec []float32) []float64 {
+	if len(current) == 0 {
+		return float32To64(vec)
+	}
+	if len(vec) == 0 {
+		return current
+	}
+	if len(current) != len(vec) {
+		return current
+	}
+	for i := range current {
+		current[i] = (current[i] + float64(vec[i])) / 2
+	}
+	return current
+}
+
+func float32To64(vec []float32) []float64 {
+	out := make([]float64, len(vec))
+	for i, v := range vec {
+		out[i] = float64(v)
+	}
+	return out
+}
+
+func float32Slice(vec []float64) []float32 {
+	out := make([]float32, len(vec))
+	for i, v := range vec {
+		out[i] = float32(v)
+	}
+	return out
+}
+
+func cosineSimilarity(a, b []float32) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	var dot, normA, normB float64
+	length := len(a)
+	if len(b) < length {
+		length = len(b)
+	}
+	for i := 0; i < length; i++ {
+		dot += float64(a[i]) * float64(b[i])
+		normA += float64(a[i]) * float64(a[i])
+		normB += float64(b[i]) * float64(b[i])
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}
+
+func clamp(val, minVal, maxVal float64) float64 {
+	if val < minVal {
+		return minVal
+	}
+	if val > maxVal {
+		return maxVal
+	}
+	return val
+}

--- a/pkg/memory/engine_bench_test.go
+++ b/pkg/memory/engine_bench_test.go
@@ -1,0 +1,27 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func BenchmarkEngineRetrieve(b *testing.B) {
+	store := NewInMemoryStore()
+	opts := Options{HalfLife: time.Hour, TTL: 720 * time.Hour}
+	engine := NewEngine(store, opts).WithEmbedder(DummyEmbedder{})
+	ctx := context.Background()
+
+	for i := 0; i < 500; i++ {
+		content := fmt.Sprintf("Document %d about system design", i)
+		engine.Store(ctx, "bench", content, map[string]any{"source": "docs"})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := engine.Retrieve(ctx, "system design", 5); err != nil {
+			b.Fatalf("retrieve: %v", err)
+		}
+	}
+}

--- a/pkg/memory/engine_test.go
+++ b/pkg/memory/engine_test.go
@@ -1,0 +1,112 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestEngineWeightedRetrievalAndSummaries(t *testing.T) {
+	store := NewInMemoryStore()
+	now := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	opts := Options{
+		Weights:  ScoreWeights{Similarity: 0.55, Importance: 0.25, Recency: 0.15, Source: 0.05},
+		HalfLife: 24 * time.Hour,
+		TTL:      720 * time.Hour,
+		SourceBoost: map[string]float64{
+			"default":   0.6,
+			"pagerduty": 1.0,
+		},
+		Clock: func() time.Time { return now },
+	}
+	engine := NewEngine(store, opts).WithEmbedder(DummyEmbedder{}).WithSummarizer(HeuristicSummarizer{})
+	ctx := context.Background()
+
+	if _, err := engine.Store(ctx, "team", "Critical production outage impacting users", map[string]any{"source": "pagerduty"}); err != nil {
+		t.Fatalf("store critical memory: %v", err)
+	}
+	if _, err := engine.Store(ctx, "team", "Lunch options for tomorrow", map[string]any{"source": "slack"}); err != nil {
+		t.Fatalf("store low priority memory: %v", err)
+	}
+
+	records, err := engine.Retrieve(ctx, "production issue", 2)
+	if err != nil {
+		t.Fatalf("retrieve: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+	if records[0].Importance < records[1].Importance {
+		t.Fatalf("expected high importance record first: got %.2f < %.2f", records[0].Importance, records[1].Importance)
+	}
+	if records[0].Summary == "" {
+		t.Fatalf("expected summary to be populated")
+	}
+}
+
+func TestEngineDeduplicationAndPrune(t *testing.T) {
+	store := NewInMemoryStore()
+	now := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	opts := Options{
+		TTL:   time.Hour,
+		Clock: func() time.Time { return now },
+	}
+	engine := NewEngine(store, opts).WithEmbedder(DummyEmbedder{})
+	ctx := context.Background()
+
+	rec, err := engine.Store(ctx, "alpha", "System upgrade completed", nil)
+	if err != nil {
+		t.Fatalf("store initial memory: %v", err)
+	}
+	beforeCount, _ := store.Count(ctx)
+	if _, err := engine.Store(ctx, "alpha", "System upgrade completed", nil); err != nil {
+		t.Fatalf("store duplicate: %v", err)
+	}
+	afterCount, _ := store.Count(ctx)
+	if beforeCount != afterCount {
+		t.Fatalf("duplicate should not increase count: before=%d after=%d", beforeCount, afterCount)
+	}
+
+	store.mu.Lock()
+	entry := store.records[rec.ID]
+	entry.CreatedAt = now.Add(-2 * opts.TTL)
+	store.records[rec.ID] = entry
+	store.mu.Unlock()
+
+	if err := engine.Prune(ctx); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	remaining, _ := store.Count(ctx)
+	if remaining != 0 {
+		t.Fatalf("expected prune to remove expired record, got %d", remaining)
+	}
+}
+
+func TestEngineReembedOnDrift(t *testing.T) {
+	store := NewInMemoryStore()
+	opts := Options{HalfLife: time.Second}
+	engine := NewEngine(store, opts).WithEmbedder(DummyEmbedder{})
+	ctx := context.Background()
+
+	rec, err := engine.Store(ctx, "beta", "Investigate latency regression", nil)
+	if err != nil {
+		t.Fatalf("store memory: %v", err)
+	}
+
+	store.mu.Lock()
+	entry := store.records[rec.ID]
+	for i := range entry.Embedding {
+		entry.Embedding[i] = 0
+	}
+	entry.LastEmbedded = time.Now().Add(-2 * opts.HalfLife)
+	store.records[rec.ID] = entry
+	store.mu.Unlock()
+
+	if _, err := engine.Retrieve(ctx, "latency", 1); err != nil {
+		t.Fatalf("retrieve: %v", err)
+	}
+	snap := engine.MetricsSnapshot()
+	if snap.Reembedded == 0 {
+		t.Fatalf("expected drift re-embedding metric to increment")
+	}
+}

--- a/pkg/memory/example_test.go
+++ b/pkg/memory/example_test.go
@@ -1,0 +1,19 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+)
+
+func ExampleNewEngine() {
+	store := NewInMemoryStore()
+	engine := NewEngine(store, Options{}).WithEmbedder(DummyEmbedder{})
+	ctx := context.Background()
+
+	engine.Store(ctx, "demo", "Track onboarding progress", map[string]any{"source": "notion"})
+	engine.Store(ctx, "demo", "Customer reported login issue", map[string]any{"source": "support"})
+
+	records, _ := engine.Retrieve(ctx, "login", 1)
+	fmt.Println(len(records) > 0)
+	// Output: true
+}

--- a/pkg/memory/in_memory_store.go
+++ b/pkg/memory/in_memory_store.go
@@ -1,0 +1,118 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+)
+
+// InMemoryStore implements VectorStore for tests and lightweight deployments.
+type InMemoryStore struct {
+	mu      sync.RWMutex
+	nextID  int64
+	records map[int64]MemoryRecord
+}
+
+func NewInMemoryStore() *InMemoryStore {
+	return &InMemoryStore{records: make(map[int64]MemoryRecord)}
+}
+
+func (s *InMemoryStore) StoreMemory(_ context.Context, sessionID, content string, metadata map[string]any, embedding []float32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.records == nil {
+		s.records = make(map[int64]MemoryRecord)
+	}
+	now := time.Now().UTC()
+	importance, source, summary, lastEmbedded, metadataJSON := normalizeMetadata(metadata, now)
+	s.nextID++
+	record := MemoryRecord{
+		ID:           s.nextID,
+		SessionID:    sessionID,
+		Content:      content,
+		Metadata:     metadataJSON,
+		Embedding:    append([]float32(nil), embedding...),
+		Importance:   importance,
+		Source:       source,
+		Summary:      summary,
+		CreatedAt:    now,
+		LastEmbedded: lastEmbedded,
+	}
+	s.records[record.ID] = record
+	return nil
+}
+
+func (s *InMemoryStore) SearchMemory(_ context.Context, queryEmbedding []float32, limit int) ([]MemoryRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if limit <= 0 {
+		return nil, nil
+	}
+	type scored struct {
+		rec   MemoryRecord
+		score float64
+	}
+	scoredRecords := make([]scored, 0, len(s.records))
+	for _, rec := range s.records {
+		score := cosineSimilarity(queryEmbedding, rec.Embedding)
+		rec.Score = score
+		scoredRecords = append(scoredRecords, scored{rec: rec, score: score})
+	}
+	sort.Slice(scoredRecords, func(i, j int) bool {
+		return scoredRecords[i].score > scoredRecords[j].score
+	})
+	if len(scoredRecords) > limit {
+		scoredRecords = scoredRecords[:limit]
+	}
+	result := make([]MemoryRecord, len(scoredRecords))
+	for i, sc := range scoredRecords {
+		result[i] = sc.rec
+	}
+	return result, nil
+}
+
+func (s *InMemoryStore) UpdateEmbedding(_ context.Context, id int64, embedding []float32, lastEmbedded time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec, ok := s.records[id]
+	if !ok {
+		return errors.New("memory not found")
+	}
+	rec.Embedding = append([]float32(nil), embedding...)
+	rec.LastEmbedded = lastEmbedded
+	s.records[id] = rec
+	return nil
+}
+
+func (s *InMemoryStore) DeleteMemory(_ context.Context, ids []int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, id := range ids {
+		delete(s.records, id)
+	}
+	return nil
+}
+
+func (s *InMemoryStore) Iterate(_ context.Context, fn func(MemoryRecord) bool) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ids := make([]int64, 0, len(s.records))
+	for id := range s.records {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return s.records[ids[i]].CreatedAt.Before(s.records[ids[j]].CreatedAt) })
+	for _, id := range ids {
+		if !fn(s.records[id]) {
+			break
+		}
+	}
+	return nil
+}
+
+func (s *InMemoryStore) Count(_ context.Context) (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.records), nil
+}

--- a/pkg/memory/metadata.go
+++ b/pkg/memory/metadata.go
@@ -1,0 +1,119 @@
+package memory
+
+import (
+	"encoding/json"
+	"time"
+)
+
+func normalizeMetadata(meta map[string]any, fallback time.Time) (importance float64, source, summary string, lastEmbedded time.Time, jsonString string) {
+	meta = cloneMetadata(meta)
+	importance = floatFromAny(meta["importance"])
+	source = stringFromAny(meta["source"])
+	summary = stringFromAny(meta["summary"])
+	lastEmbedded = timeFromAny(meta["last_embedded"])
+	if lastEmbedded.IsZero() {
+		if fallback.IsZero() {
+			fallback = time.Now().UTC()
+		}
+		lastEmbedded = fallback
+	}
+	meta["importance"] = importance
+	meta["source"] = source
+	meta["summary"] = summary
+	meta["last_embedded"] = lastEmbedded.UTC().Format(time.RFC3339Nano)
+	jsonBytes, _ := json.Marshal(meta)
+	jsonString = string(jsonBytes)
+	return
+}
+
+func cloneMetadata(meta map[string]any) map[string]any {
+	if meta == nil {
+		return map[string]any{}
+	}
+	cp := make(map[string]any, len(meta))
+	for k, v := range meta {
+		cp[k] = v
+	}
+	return cp
+}
+
+func floatFromAny(v any) float64 {
+	switch t := v.(type) {
+	case float64:
+		return t
+	case float32:
+		return float64(t)
+	case int:
+		return float64(t)
+	case int64:
+		return float64(t)
+	case json.Number:
+		f, _ := t.Float64()
+		return f
+	case string:
+		var f float64
+		if err := json.Unmarshal([]byte(t), &f); err == nil {
+			return f
+		}
+	}
+	return 0
+}
+
+func stringFromAny(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func timeFromAny(v any) time.Time {
+	switch t := v.(type) {
+	case time.Time:
+		return t
+	case string:
+		ts, err := time.Parse(time.RFC3339Nano, t)
+		if err == nil {
+			return ts
+		}
+	}
+	return time.Time{}
+}
+
+func decodeMetadata(metadata string) map[string]any {
+	if metadata == "" {
+		return map[string]any{}
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(metadata), &meta); err != nil {
+		return map[string]any{}
+	}
+	return meta
+}
+
+func hydrateRecordFromMetadata(rec *MemoryRecord, meta map[string]any) {
+	if rec == nil {
+		return
+	}
+	if rec.Importance == 0 {
+		rec.Importance = floatFromAny(meta["importance"])
+	}
+	if rec.Source == "" {
+		rec.Source = stringFromAny(meta["source"])
+	}
+	if rec.Summary == "" {
+		rec.Summary = stringFromAny(meta["summary"])
+	}
+	if rec.LastEmbedded.IsZero() {
+		if ts := timeFromAny(meta["last_embedded"]); !ts.IsZero() {
+			rec.LastEmbedded = ts
+		}
+	}
+}

--- a/pkg/memory/metrics.go
+++ b/pkg/memory/metrics.go
@@ -1,0 +1,44 @@
+package memory
+
+import "sync/atomic"
+
+// Metrics captures lightweight runtime counters for observability.
+type Metrics struct {
+	stored             atomic.Int64
+	retrieved          atomic.Int64
+	deduplicated       atomic.Int64
+	reembedded         atomic.Int64
+	pruned             atomic.Int64
+	clustersSummarized atomic.Int64
+}
+
+func (m *Metrics) IncStored()             { m.stored.Add(1) }
+func (m *Metrics) IncRetrieved(n int)     { m.retrieved.Add(int64(n)) }
+func (m *Metrics) IncDeduplicated()       { m.deduplicated.Add(1) }
+func (m *Metrics) IncReembedded()         { m.reembedded.Add(1) }
+func (m *Metrics) IncPruned(n int)        { m.pruned.Add(int64(n)) }
+func (m *Metrics) IncClustersSummarized() { m.clustersSummarized.Add(1) }
+
+// Snapshot returns the current values for reporting/logging.
+type MetricsSnapshot struct {
+	Stored             int64 `json:"stored"`
+	Retrieved          int64 `json:"retrieved"`
+	Deduplicated       int64 `json:"deduplicated"`
+	Reembedded         int64 `json:"reembedded"`
+	Pruned             int64 `json:"pruned"`
+	ClustersSummarized int64 `json:"clusters_summarized"`
+}
+
+func (m *Metrics) Snapshot() MetricsSnapshot {
+	if m == nil {
+		return MetricsSnapshot{}
+	}
+	return MetricsSnapshot{
+		Stored:             m.stored.Load(),
+		Retrieved:          m.retrieved.Load(),
+		Deduplicated:       m.deduplicated.Load(),
+		Reembedded:         m.reembedded.Load(),
+		Pruned:             m.pruned.Load(),
+		ClustersSummarized: m.clustersSummarized.Load(),
+	}
+}

--- a/pkg/memory/options.go
+++ b/pkg/memory/options.go
@@ -1,0 +1,102 @@
+package memory
+
+import "time"
+
+// ScoreWeights controls the contribution of each scoring component during retrieval.
+type ScoreWeights struct {
+	Similarity float64
+	Importance float64
+	Recency    float64
+	Source     float64
+}
+
+// Options configures the advanced memory engine.
+type Options struct {
+	Weights             ScoreWeights
+	LambdaMMR           float64
+	HalfLife            time.Duration
+	ClusterSimilarity   float64
+	DriftThreshold      float64
+	DuplicateSimilarity float64
+	TTL                 time.Duration
+	MaxSize             int
+	SourceBoost         map[string]float64
+	Clock               func() time.Time
+	EnableSummaries     bool
+	DisableSummaries    bool
+}
+
+// DefaultOptions returns the recommended defaults for the advanced memory engine.
+func DefaultOptions() Options {
+	return Options{
+		Weights: ScoreWeights{
+			Similarity: 0.55,
+			Importance: 0.25,
+			Recency:    0.15,
+			Source:     0.05,
+		},
+		LambdaMMR:           0.7,
+		HalfLife:            72 * time.Hour,
+		ClusterSimilarity:   0.83,
+		DriftThreshold:      0.90,
+		DuplicateSimilarity: 0.97,
+		TTL:                 720 * time.Hour,
+		MaxSize:             200_000,
+		SourceBoost:         map[string]float64{"default": 1},
+		EnableSummaries:     true,
+		DisableSummaries:    false,
+	}
+}
+
+func (o Options) withDefaults() Options {
+	defaults := DefaultOptions()
+	if o.Weights.Similarity == 0 && o.Weights.Importance == 0 && o.Weights.Recency == 0 && o.Weights.Source == 0 {
+		o.Weights = defaults.Weights
+	}
+	if o.LambdaMMR == 0 {
+		o.LambdaMMR = defaults.LambdaMMR
+	}
+	if o.HalfLife == 0 {
+		o.HalfLife = defaults.HalfLife
+	}
+	if o.ClusterSimilarity == 0 {
+		o.ClusterSimilarity = defaults.ClusterSimilarity
+	}
+	if o.DriftThreshold == 0 {
+		o.DriftThreshold = defaults.DriftThreshold
+	}
+	if o.DuplicateSimilarity == 0 {
+		o.DuplicateSimilarity = defaults.DuplicateSimilarity
+	}
+	if o.TTL == 0 {
+		o.TTL = defaults.TTL
+	}
+	if o.MaxSize == 0 {
+		o.MaxSize = defaults.MaxSize
+	}
+	if o.SourceBoost == nil {
+		o.SourceBoost = defaults.SourceBoost
+	}
+	if o.Clock == nil {
+		o.Clock = time.Now
+	}
+	if o.DisableSummaries {
+		o.EnableSummaries = false
+	} else if !o.EnableSummaries {
+		o.EnableSummaries = defaults.EnableSummaries
+	}
+	return o
+}
+
+func (o Options) normalizedWeights() ScoreWeights {
+	total := o.Weights.Similarity + o.Weights.Importance + o.Weights.Recency + o.Weights.Source
+	if total == 0 {
+		return o.Weights
+	}
+	return ScoreWeights{
+		Similarity: o.Weights.Similarity / total,
+		Importance: o.Weights.Importance / total,
+		Recency:    o.Weights.Recency / total,
+		Source:     o.Weights.Source / total,
+	}
+}

--- a/pkg/memory/postgres_store.go
+++ b/pkg/memory/postgres_store.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -25,16 +27,18 @@ func NewPostgresStore(ctx context.Context, connStr string) (*PostgresStore, erro
 }
 
 // StoreMemory inserts a long-term record into Postgres.
-func (ps *PostgresStore) StoreMemory(ctx context.Context, sessionID, content, metadata string, embedding []float32) error {
+func (ps *PostgresStore) StoreMemory(ctx context.Context, sessionID, content string, metadata map[string]any, embedding []float32) error {
 	if ps == nil || ps.DB == nil {
 		return nil
 	}
-	jsonEmbed, _ := json.Marshal(embedding)
+	importance, source, summary, lastEmbedded, metadataJSON := normalizeMetadata(metadata, time.Now().UTC())
 	query := `
-                INSERT INTO memory_bank (session_id, content, metadata, embedding)
-                VALUES ($1, $2, $3::jsonb, $4::vector);
+                INSERT INTO memory_bank (session_id, content, metadata, embedding, importance, source, summary, last_embedded)
+                VALUES ($1, $2, $3::jsonb, $4::vector, $5, $6, $7, $8)
+                RETURNING id;
         `
-	_, err := ps.DB.Exec(ctx, query, sessionID, content, metadata, fmt.Sprintf("[%s]", trimJSON(string(jsonEmbed))))
+	jsonEmbed, _ := json.Marshal(embedding)
+	_, err := ps.DB.Exec(ctx, query, sessionID, content, metadataJSON, vectorFromJSON(jsonEmbed), importance, source, summary, lastEmbedded)
 	return err
 }
 
@@ -45,11 +49,11 @@ func (ps *PostgresStore) SearchMemory(ctx context.Context, queryEmbedding []floa
 	}
 	jsonEmbed, _ := json.Marshal(queryEmbedding)
 	rows, err := ps.DB.Query(ctx, `
-        SELECT id, session_id, content, metadata, (embedding <-> $1::vector) AS score
+        SELECT id, session_id, content, metadata::text, importance, source, summary, created_at, last_embedded, embedding::text, (embedding <-> $1::vector) AS score
         FROM memory_bank
         ORDER BY embedding <-> $1::vector
         LIMIT $2;
-        `, fmt.Sprintf("[%s]", trimJSON(string(jsonEmbed))), limit)
+        `, vectorFromJSON(jsonEmbed), limit)
 	if err != nil {
 		return nil, err
 	}
@@ -58,12 +62,75 @@ func (ps *PostgresStore) SearchMemory(ctx context.Context, queryEmbedding []floa
 	var records []MemoryRecord
 	for rows.Next() {
 		var rec MemoryRecord
-		if err := rows.Scan(&rec.ID, &rec.SessionID, &rec.Content, &rec.Metadata, &rec.Score); err != nil {
+		var embeddingText string
+		if err := rows.Scan(&rec.ID, &rec.SessionID, &rec.Content, &rec.Metadata, &rec.Importance, &rec.Source, &rec.Summary, &rec.CreatedAt, &rec.LastEmbedded, &embeddingText, &rec.Score); err != nil {
 			return nil, err
 		}
+		rec.Embedding = parseVector(embeddingText)
+		hydrateRecordFromMetadata(&rec, decodeMetadata(rec.Metadata))
+		rec.Score = 1 - rec.Score
 		records = append(records, rec)
 	}
 	return records, nil
+}
+
+func (ps *PostgresStore) UpdateEmbedding(ctx context.Context, id int64, embedding []float32, lastEmbedded time.Time) error {
+	if ps == nil || ps.DB == nil {
+		return nil
+	}
+	jsonEmbed, _ := json.Marshal(embedding)
+	_, err := ps.DB.Exec(ctx, `
+                UPDATE memory_bank
+                SET embedding = $2::vector, last_embedded = $3
+                WHERE id = $1
+        `, id, vectorFromJSON(jsonEmbed), lastEmbedded)
+	return err
+}
+
+func (ps *PostgresStore) DeleteMemory(ctx context.Context, ids []int64) error {
+	if ps == nil || ps.DB == nil || len(ids) == 0 {
+		return nil
+	}
+	_, err := ps.DB.Exec(ctx, `DELETE FROM memory_bank WHERE id = ANY($1)`, ids)
+	return err
+}
+
+func (ps *PostgresStore) Iterate(ctx context.Context, fn func(MemoryRecord) bool) error {
+	if ps == nil || ps.DB == nil {
+		return nil
+	}
+	rows, err := ps.DB.Query(ctx, `
+        SELECT id, session_id, content, metadata::text, importance, source, summary, created_at, last_embedded, embedding::text
+        FROM memory_bank
+        ORDER BY created_at ASC
+        `)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var rec MemoryRecord
+		var embeddingText string
+		if err := rows.Scan(&rec.ID, &rec.SessionID, &rec.Content, &rec.Metadata, &rec.Importance, &rec.Source, &rec.Summary, &rec.CreatedAt, &rec.LastEmbedded, &embeddingText); err != nil {
+			return err
+		}
+		rec.Embedding = parseVector(embeddingText)
+		hydrateRecordFromMetadata(&rec, decodeMetadata(rec.Metadata))
+		cont := fn(rec)
+		if !cont {
+			break
+		}
+	}
+	return rows.Err()
+}
+
+func (ps *PostgresStore) Count(ctx context.Context) (int, error) {
+	if ps == nil || ps.DB == nil {
+		return 0, nil
+	}
+	var count int
+	err := ps.DB.QueryRow(ctx, `SELECT COUNT(*) FROM memory_bank`).Scan(&count)
+	return count, err
 }
 
 // CreateSchema ensures pgvector extension and memory table are available.
@@ -112,4 +179,30 @@ CREATE TABLE IF NOT EXISTS memory_bank (
 
 CREATE INDEX IF NOT EXISTS memory_session_idx ON memory_bank (session_id);
 CREATE INDEX IF NOT EXISTS memory_embedding_idx ON memory_bank USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+
+ALTER TABLE memory_bank ADD COLUMN IF NOT EXISTS importance DOUBLE PRECISION DEFAULT 0;
+ALTER TABLE memory_bank ADD COLUMN IF NOT EXISTS source TEXT DEFAULT '';
+ALTER TABLE memory_bank ADD COLUMN IF NOT EXISTS summary TEXT DEFAULT '';
+ALTER TABLE memory_bank ADD COLUMN IF NOT EXISTS last_embedded TIMESTAMPTZ DEFAULT NOW();
 `
+
+func vectorFromJSON(jsonEmbed []byte) string {
+	return fmt.Sprintf("[%s]", trimJSON(string(jsonEmbed)))
+}
+
+func parseVector(text string) []float32 {
+	text = strings.Trim(text, "[]")
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	parts := strings.Split(text, ",")
+	vec := make([]float32, 0, len(parts))
+	for _, part := range parts {
+		f, err := strconv.ParseFloat(strings.TrimSpace(part), 32)
+		if err != nil {
+			continue
+		}
+		vec = append(vec, float32(f))
+	}
+	return vec
+}

--- a/pkg/memory/summarizer.go
+++ b/pkg/memory/summarizer.go
@@ -1,0 +1,29 @@
+package memory
+
+import (
+	"context"
+	"strings"
+)
+
+// Summarizer abstracts cluster summarization backends (LLMs or heuristics).
+type Summarizer interface {
+	Summarize(ctx context.Context, cluster []MemoryRecord) (string, error)
+}
+
+// HeuristicSummarizer produces deterministic summaries suitable for tests.
+type HeuristicSummarizer struct{}
+
+func (HeuristicSummarizer) Summarize(_ context.Context, cluster []MemoryRecord) (string, error) {
+	if len(cluster) == 0 {
+		return "", nil
+	}
+	var sentences []string
+	for _, rec := range cluster {
+		sentences = append(sentences, rec.Content)
+	}
+	summary := strings.Join(sentences, " ")
+	if len(summary) > 280 {
+		summary = summary[:280]
+	}
+	return summary, nil
+}

--- a/pkg/memory/vector_store.go
+++ b/pkg/memory/vector_store.go
@@ -1,11 +1,18 @@
 package memory
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // VectorStore defines the contract for long-term memory backends.
 type VectorStore interface {
-	StoreMemory(ctx context.Context, sessionID, content, metadata string, embedding []float32) error
+	StoreMemory(ctx context.Context, sessionID, content string, metadata map[string]any, embedding []float32) error
 	SearchMemory(ctx context.Context, queryEmbedding []float32, limit int) ([]MemoryRecord, error)
+	UpdateEmbedding(ctx context.Context, id int64, embedding []float32, lastEmbedded time.Time) error
+	DeleteMemory(ctx context.Context, ids []int64) error
+	Iterate(ctx context.Context, fn func(MemoryRecord) bool) error
+	Count(ctx context.Context) (int, error)
 }
 
 // SchemaInitializer allows stores to expose optional schema/bootstrap routines.


### PR DESCRIPTION
## Summary
- enforce importance-first ordering when ranking retrieved memories while retaining weighted tie-breakers
- add an explicit disable flag to options so summary generation stays enabled by default yet can be turned off
- propagate the new disable flag through the demo CLI configuration so runtime flags still control summarisation

## Testing
- `GOPROXY=off go test ./pkg/memory -run TestEngineWeightedRetrievalAndSummaries -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ee729d3c4883228730526de60a03f3