### PR TITLE
Expose metrics for memory policy enforcement

### DIFF
--- a/pkg/memory/engine_test.go
+++ b/pkg/memory/engine_test.go
@@ -42,6 +42,13 @@ func TestEngineWeightedRetrievalAndSummaries(t *testing.T) {
 	if records[0].Summary == "" {
 		t.Fatalf("expected summary to be populated")
 	}
+	snap := engine.MetricsSnapshot()
+	if snap.ClustersSummarized == 0 {
+		t.Fatalf("expected summarization metrics to record cluster summaries")
+	}
+	if snap.RecencySamples == 0 || snap.RecencyDecayAvg <= 0 {
+		t.Fatalf("expected recency observations to be tracked, got samples=%d avg=%.4f", snap.RecencySamples, snap.RecencyDecayAvg)
+	}
 }
 
 func TestEngineDeduplicationAndPrune(t *testing.T) {
@@ -79,6 +86,13 @@ func TestEngineDeduplicationAndPrune(t *testing.T) {
 	remaining, _ := store.Count(ctx)
 	if remaining != 0 {
 		t.Fatalf("expected prune to remove expired record, got %d", remaining)
+	}
+	snap := engine.MetricsSnapshot()
+	if snap.Deduplicated == 0 {
+		t.Fatalf("expected deduplication metric to increment")
+	}
+	if snap.TTLExpired == 0 {
+		t.Fatalf("expected TTL expiration metric to increment")
 	}
 }
 

--- a/pkg/memory/metrics.go
+++ b/pkg/memory/metrics.go
@@ -10,6 +10,10 @@ type Metrics struct {
 	reembedded         atomic.Int64
 	pruned             atomic.Int64
 	clustersSummarized atomic.Int64
+	ttlExpired         atomic.Int64
+	sizeEvicted        atomic.Int64
+	recencySamples     atomic.Int64
+	recencySumMicros   atomic.Int64
 }
 
 func (m *Metrics) IncStored()             { m.stored.Add(1) }
@@ -18,20 +22,42 @@ func (m *Metrics) IncDeduplicated()       { m.deduplicated.Add(1) }
 func (m *Metrics) IncReembedded()         { m.reembedded.Add(1) }
 func (m *Metrics) IncPruned(n int)        { m.pruned.Add(int64(n)) }
 func (m *Metrics) IncClustersSummarized() { m.clustersSummarized.Add(1) }
+func (m *Metrics) IncTTLExpired(n int)    { m.ttlExpired.Add(int64(n)) }
+func (m *Metrics) IncSizeEvicted(n int)   { m.sizeEvicted.Add(int64(n)) }
+func (m *Metrics) ObserveRecency(decay float64) {
+	if decay < 0 {
+		decay = 0
+	}
+	if decay > 1 {
+		decay = 1
+	}
+	m.recencySamples.Add(1)
+	m.recencySumMicros.Add(int64(decay * 1_000_000))
+}
 
 // Snapshot returns the current values for reporting/logging.
 type MetricsSnapshot struct {
-	Stored             int64 `json:"stored"`
-	Retrieved          int64 `json:"retrieved"`
-	Deduplicated       int64 `json:"deduplicated"`
-	Reembedded         int64 `json:"reembedded"`
-	Pruned             int64 `json:"pruned"`
-	ClustersSummarized int64 `json:"clusters_summarized"`
+	Stored             int64   `json:"stored"`
+	Retrieved          int64   `json:"retrieved"`
+	Deduplicated       int64   `json:"deduplicated"`
+	Reembedded         int64   `json:"reembedded"`
+	Pruned             int64   `json:"pruned"`
+	ClustersSummarized int64   `json:"clusters_summarized"`
+	TTLExpired         int64   `json:"ttl_expired"`
+	SizeEvicted        int64   `json:"size_evicted"`
+	RecencySamples     int64   `json:"recency_samples"`
+	RecencyDecayAvg    float64 `json:"recency_decay_avg"`
 }
 
 func (m *Metrics) Snapshot() MetricsSnapshot {
 	if m == nil {
 		return MetricsSnapshot{}
+	}
+	samples := m.recencySamples.Load()
+	sumMicros := m.recencySumMicros.Load()
+	avg := 0.0
+	if samples > 0 {
+		avg = float64(sumMicros) / 1_000_000 / float64(samples)
 	}
 	return MetricsSnapshot{
 		Stored:             m.stored.Load(),
@@ -40,5 +66,9 @@ func (m *Metrics) Snapshot() MetricsSnapshot {
 		Reembedded:         m.reembedded.Load(),
 		Pruned:             m.pruned.Load(),
 		ClustersSummarized: m.clustersSummarized.Load(),
+		TTLExpired:         m.ttlExpired.Load(),
+		SizeEvicted:        m.sizeEvicted.Load(),
+		RecencySamples:     samples,
+		RecencyDecayAvg:    avg,
 	}
 }


### PR DESCRIPTION
## Summary
- add explicit counters for TTL pruning, size evictions, and recency decay observations to the memory engine metrics snapshot
- update pruning and retrieval flows to populate the new metrics and guard batch deletions with reason metadata
- extend memory engine tests to assert summarization, TTL, and deduplication counters are exposed

## Testing
- go test ./... -count=1
