### PR TITLE
Add upload file support for all model adapters

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Raezil/go-agent-development-kit/pkg/memory"
+	"github.com/Raezil/go-agent-development-kit/pkg/models"
 )
 
 type stubModel struct {
@@ -18,6 +19,10 @@ func (m *stubModel) Generate(ctx context.Context, prompt string) (any, error) {
 		return nil, m.err
 	}
 	return m.response + " | " + prompt, nil
+}
+
+func (m *stubModel) UploadFiles(context.Context, []models.UploadFile) ([]models.UploadedFile, error) {
+	return nil, nil
 }
 
 type stubTool struct {

--- a/pkg/models/dummy.go
+++ b/pkg/models/dummy.go
@@ -34,4 +34,28 @@ func (d *DummyLLM) Generate(_ context.Context, prompt string) (any, error) {
 	return fmt.Sprintf("%s %s", d.Prefix, last), nil
 }
 
+func (d *DummyLLM) UploadFiles(_ context.Context, files []UploadFile) ([]UploadedFile, error) {
+	uploads := make([]UploadedFile, 0, len(files))
+	for _, file := range files {
+		resolved, err := file.resolve()
+		if err != nil {
+			return nil, err
+		}
+		name := resolved.name
+		if name == "" {
+			name = "upload"
+		}
+		uploads = append(uploads, UploadedFile{
+			ID:        fmt.Sprintf("dummy-%s", name),
+			Name:      name,
+			SizeBytes: resolved.size,
+			MIMEType:  resolved.mimeType,
+			Provider:  "dummy",
+			Purpose:   file.Purpose,
+		})
+		resolved.Close()
+	}
+	return uploads, nil
+}
+
 var _ Agent = (*DummyLLM)(nil)

--- a/pkg/models/gemini.go
+++ b/pkg/models/gemini.go
@@ -53,3 +53,71 @@ func (g *GeminiLLM) Generate(ctx context.Context, prompt string) (any, error) {
 
 	return resp.Candidates[0].Content.Parts[0], nil
 }
+
+func (g *GeminiLLM) UploadFiles(ctx context.Context, files []UploadFile) ([]UploadedFile, error) {
+	uploads := make([]UploadedFile, 0, len(files))
+	for _, file := range files {
+		path := strings.TrimSpace(file.Path)
+		displayName := strings.TrimSpace(file.Name)
+		mimeHint := strings.TrimSpace(file.MIMEType)
+		if file.Reader == nil && path != "" {
+			gemFile, err := g.Client.UploadFileFromPath(ctx, path, geminiUploadOptions(displayName, mimeHint))
+			if err != nil {
+				return nil, fmt.Errorf("gemini upload %s: %w", path, err)
+			}
+			uploads = append(uploads, geminiUploadedFile(gemFile, file.Purpose))
+			continue
+		}
+
+		resolved, err := file.resolve()
+		if err != nil {
+			return nil, err
+		}
+		nameHint := displayName
+		if nameHint == "" {
+			nameHint = resolved.name
+		}
+		mime := resolved.mimeType
+		if mime == "" {
+			mime = mimeHint
+		}
+		gemFile, uploadErr := g.Client.UploadFile(ctx, "", resolved.reader, geminiUploadOptions(nameHint, mime))
+		closeErr := resolved.Close()
+		if uploadErr == nil {
+			uploadErr = closeErr
+		}
+		if uploadErr != nil {
+			return nil, uploadErr
+		}
+		uploads = append(uploads, geminiUploadedFile(gemFile, file.Purpose))
+	}
+	return uploads, nil
+}
+
+func geminiUploadOptions(displayName, mimeType string) *genai.UploadFileOptions {
+	displayName = strings.TrimSpace(displayName)
+	mimeType = strings.TrimSpace(mimeType)
+	if displayName == "" && mimeType == "" {
+		return nil
+	}
+	return &genai.UploadFileOptions{DisplayName: displayName, MIMEType: mimeType}
+}
+
+func geminiUploadedFile(file *genai.File, purpose string) UploadedFile {
+	if file == nil {
+		return UploadedFile{Provider: "gemini", Purpose: purpose}
+	}
+	name := file.DisplayName
+	if strings.TrimSpace(name) == "" {
+		name = file.Name
+	}
+	return UploadedFile{
+		ID:        file.Name,
+		Name:      name,
+		SizeBytes: file.SizeBytes,
+		MIMEType:  file.MIMEType,
+		URI:       file.URI,
+		Provider:  "gemini",
+		Purpose:   purpose,
+	}
+}

--- a/pkg/models/interface.go
+++ b/pkg/models/interface.go
@@ -2,8 +2,134 @@ package models
 
 import (
 	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
+// Agent defines the core contract that all model adapters must satisfy.
 type Agent interface {
 	Generate(context.Context, string) (any, error)
+	UploadFiles(context.Context, []UploadFile) ([]UploadedFile, error)
+}
+
+// UploadFile represents a local or in-memory file that should be uploaded to a
+// model provider. Either Path or Reader must be supplied. Optional metadata can
+// be provided via Name, MIMEType, and Purpose.
+type UploadFile struct {
+	Name     string
+	Path     string
+	Reader   io.Reader
+	MIMEType string
+	Purpose  string
+}
+
+// UploadedFile captures the identifier and metadata returned from a provider
+// when a file upload succeeds. The Data field is populated for providers that
+// return the raw bytes (e.g. Ollama image uploads) instead of a remote handle.
+type UploadedFile struct {
+	ID        string
+	Name      string
+	SizeBytes int64
+	MIMEType  string
+	URI       string
+	Provider  string
+	Purpose   string
+	Data      []byte
+}
+
+type resolvedUpload struct {
+	reader   *uploadReader
+	name     string
+	mimeType string
+	path     string
+	size     int64
+}
+
+// Close releases the underlying reader for the resolved upload.
+func (r *resolvedUpload) Close() error {
+	if r == nil || r.reader == nil {
+		return nil
+	}
+	return r.reader.Close()
+}
+
+// uploadReader wraps an io.ReadCloser to expose filename and MIME type hints so
+// SDKs that inspect optional interfaces (e.g. Anthropic) can populate metadata.
+type uploadReader struct {
+	io.ReadCloser
+	name string
+	mime string
+}
+
+func (r *uploadReader) Filename() string { return r.name }
+
+func (r *uploadReader) Name() string { return r.name }
+
+func (r *uploadReader) ContentType() string {
+	if r.mime != "" {
+		return r.mime
+	}
+	return "application/octet-stream"
+}
+
+func (f UploadFile) resolve() (*resolvedUpload, error) {
+	var (
+		rc   io.ReadCloser
+		size int64
+		path string
+	)
+
+	if f.Reader != nil {
+		if closer, ok := f.Reader.(io.ReadCloser); ok {
+			rc = closer
+		} else {
+			rc = io.NopCloser(f.Reader)
+		}
+	} else {
+		if strings.TrimSpace(f.Path) == "" {
+			return nil, errors.New("upload file requires either Path or Reader")
+		}
+		file, err := os.Open(f.Path)
+		if err != nil {
+			return nil, err
+		}
+		rc = file
+		path = f.Path
+		if info, err := file.Stat(); err == nil {
+			size = info.Size()
+		}
+	}
+
+	name := strings.TrimSpace(f.Name)
+	if name == "" {
+		switch {
+		case path != "":
+			name = filepath.Base(path)
+		case f.Reader != nil:
+			if named, ok := f.Reader.(interface{ Name() string }); ok {
+				name = filepath.Base(strings.TrimSpace(named.Name()))
+			}
+		}
+	}
+	if name == "" {
+		name = "upload"
+	}
+
+	mimeType := strings.TrimSpace(f.MIMEType)
+	if mimeType == "" {
+		if typed, ok := f.Reader.(interface{ ContentType() string }); ok {
+			mimeType = strings.TrimSpace(typed.ContentType())
+		}
+	}
+
+	return &resolvedUpload{
+		reader:   &uploadReader{ReadCloser: rc, name: name, mime: mimeType},
+		name:     name,
+		mimeType: mimeType,
+		path:     path,
+		size:     size,
+	}, nil
 }

--- a/pkg/models/ollama.go
+++ b/pkg/models/ollama.go
@@ -2,7 +2,10 @@ package models
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -75,4 +78,41 @@ func (o *OllamaLLM) Generate(ctx context.Context, prompt string) (any, error) {
 		Done:       last.Done,
 		DoneReason: last.DoneReason,
 	}, nil
+}
+
+func (o *OllamaLLM) UploadFiles(_ context.Context, files []UploadFile) ([]UploadedFile, error) {
+	uploads := make([]UploadedFile, 0, len(files))
+	for _, file := range files {
+		resolved, err := file.resolve()
+		if err != nil {
+			return nil, err
+		}
+		data, readErr := io.ReadAll(resolved.reader)
+		closeErr := resolved.Close()
+		if readErr == nil {
+			readErr = closeErr
+		}
+		if readErr != nil {
+			return nil, readErr
+		}
+		sum := sha256.Sum256(data)
+		mimeType := resolved.mimeType
+		if mimeType == "" {
+			if len(data) > 0 {
+				mimeType = http.DetectContentType(data)
+			} else {
+				mimeType = "application/octet-stream"
+			}
+		}
+		uploads = append(uploads, UploadedFile{
+			ID:        "ollama-" + hex.EncodeToString(sum[:]),
+			Name:      resolved.name,
+			SizeBytes: int64(len(data)),
+			MIMEType:  mimeType,
+			Provider:  "ollama",
+			Purpose:   file.Purpose,
+			Data:      data,
+		})
+	}
+	return uploads, nil
 }

--- a/pkg/models/openai.go
+++ b/pkg/models/openai.go
@@ -3,7 +3,9 @@ package models
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/sashabaranov/go-openai"
 )
@@ -43,4 +45,63 @@ func (o *OpenAILLM) Generate(ctx context.Context, prompt string) (any, error) {
 		return nil, errors.New("no response from OpenAI")
 	}
 	return resp.Choices[0].Message.Content, nil
+}
+
+func (o *OpenAILLM) UploadFiles(ctx context.Context, files []UploadFile) ([]UploadedFile, error) {
+	uploads := make([]UploadedFile, 0, len(files))
+	for _, file := range files {
+		purpose := strings.TrimSpace(file.Purpose)
+		if purpose == "" {
+			purpose = string(openai.PurposeAssistants)
+		}
+		if file.Reader == nil && strings.TrimSpace(file.Path) != "" {
+			resp, err := o.Client.CreateFile(ctx, openai.FileRequest{
+				FilePath: file.Path,
+				Purpose:  purpose,
+				FileName: strings.TrimSpace(file.Name),
+			})
+			if err != nil {
+				return nil, err
+			}
+			uploads = append(uploads, UploadedFile{
+				ID:        resp.ID,
+				Name:      resp.FileName,
+				SizeBytes: int64(resp.Bytes),
+				MIMEType:  "",
+				Provider:  "openai",
+				Purpose:   resp.Purpose,
+			})
+			continue
+		}
+
+		resolved, err := file.resolve()
+		if err != nil {
+			return nil, err
+		}
+		data, readErr := io.ReadAll(resolved.reader)
+		closeErr := resolved.Close()
+		if readErr == nil {
+			readErr = closeErr
+		}
+		if readErr != nil {
+			return nil, readErr
+		}
+		resp, err := o.Client.CreateFileBytes(ctx, openai.FileBytesRequest{
+			Name:    resolved.name,
+			Bytes:   data,
+			Purpose: openai.PurposeType(purpose),
+		})
+		if err != nil {
+			return nil, err
+		}
+		uploads = append(uploads, UploadedFile{
+			ID:        resp.ID,
+			Name:      resp.FileName,
+			SizeBytes: int64(resp.Bytes),
+			MIMEType:  resolved.mimeType,
+			Provider:  "openai",
+			Purpose:   resp.Purpose,
+		})
+	}
+	return uploads, nil
 }

--- a/pkg/subagents/researcher_test.go
+++ b/pkg/subagents/researcher_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/models"
 )
 
 type fakeModel struct {
@@ -21,6 +23,10 @@ func (f *fakeModel) Generate(ctx context.Context, prompt string) (any, error) {
 		return f.response, nil
 	}
 	return "ok", nil
+}
+
+func (f *fakeModel) UploadFiles(context.Context, []models.UploadFile) ([]models.UploadedFile, error) {
+	return nil, nil
 }
 
 func TestResearcherRunIncludesPersonaAndTask(t *testing.T) {


### PR DESCRIPTION
## Summary
- extend the model interface with reusable upload request/response types
- implement UploadFiles for OpenAI, Anthropic, Gemini, Ollama, and Dummy adapters
- update test doubles to satisfy the new interface method

## Testing
- go test ./...


------