### PR TITLE
feat: add upload ingestion pipeline and examples

### DIFF
--- a/examples/uploads/ingest_pdf/main.go
+++ b/examples/uploads/ingest_pdf/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/memory"
+	"github.com/Raezil/go-agent-development-kit/pkg/uploads"
+)
+
+func main() {
+	var (
+		filePath = flag.String("pdf", "", "Path to the PDF file to ingest")
+		source   = flag.String("source", "pdf", "Logical source label")
+	)
+	flag.Parse()
+	if *filePath == "" {
+		log.Fatal("--pdf path is required")
+	}
+	f, err := os.Open(*filePath)
+	if err != nil {
+		log.Fatalf("open pdf: %v", err)
+	}
+	defer f.Close()
+
+	chunker := uploads.PDFChunker{}
+	chunks, err := chunker.Chunk(uploads.ReaderWithName{Name: filepath.Base(*filePath), Reader: f}, uploads.Source{Name: *source, URI: *filePath})
+	if err != nil {
+		log.Fatalf("chunk pdf: %v", err)
+	}
+	fmt.Printf("Extracted %d chunks\n", len(chunks))
+
+	pipeline := uploads.Pipeline{
+		Embedder:       memory.AutoEmbedder(),
+		SimilarityMode: "cosine",
+		Normalize:      true,
+		Middlewares:    []uploads.Middleware{uploads.PIIRedactor{}},
+	}
+	embedded, err := pipeline.Process(context.Background(), chunks)
+	if err != nil {
+		log.Fatalf("embed chunks: %v", err)
+	}
+	successes := 0
+	for _, res := range embedded {
+		if res.Err != nil {
+			fmt.Printf("chunk %s failed: %v\n", res.Chunk.ID, res.Err)
+			continue
+		}
+		successes++
+		fmt.Printf("chunk %s -> dim=%d\n", res.Chunk.ID, len(res.Vector))
+	}
+	fmt.Printf("Embedded %d/%d chunks\n", successes, len(embedded))
+}

--- a/examples/uploads/ingest_repo/main.go
+++ b/examples/uploads/ingest_repo/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/memory"
+	"github.com/Raezil/go-agent-development-kit/pkg/uploads"
+)
+
+func main() {
+	var (
+		repoPath = flag.String("repo", ".", "Path to the repository to ingest")
+		source   = flag.String("source", "repo", "Logical source label")
+	)
+	flag.Parse()
+
+	chunker := uploads.CodeChunker{Root: *repoPath}
+	chunks, err := chunker.Chunk(uploads.ReaderWithName{}, uploads.Source{Name: *source, URI: *repoPath})
+	if err != nil {
+		log.Fatalf("chunk repo: %v", err)
+	}
+	fmt.Printf("Discovered %d chunks\n", len(chunks))
+
+	pipeline := uploads.Pipeline{
+		Embedder:       memory.AutoEmbedder(),
+		SimilarityMode: "dot",
+		Middlewares:    []uploads.Middleware{uploads.PIIRedactor{}},
+	}
+	embedded, err := pipeline.Process(context.Background(), chunks)
+	if err != nil {
+		log.Fatalf("embed chunks: %v", err)
+	}
+	successes := 0
+	for _, res := range embedded {
+		if res.Err != nil {
+			fmt.Printf("chunk %s failed: %v\n", res.Chunk.ID, res.Err)
+			continue
+		}
+		successes++
+	}
+	fmt.Printf("Embedded %d/%d chunks\n", successes, len(embedded))
+}

--- a/examples/uploads/query/main.go
+++ b/examples/uploads/query/main.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/memory"
+	"github.com/Raezil/go-agent-development-kit/pkg/uploads"
+)
+
+func main() {
+	var (
+		pdfPath   = flag.String("pdf", "", "Optional PDF to ingest")
+		repoPath  = flag.String("repo", "", "Optional repo to ingest")
+		question  = flag.String("q", "", "Natural language question")
+		topK      = flag.Int("k", 3, "Results to display")
+		normalize = flag.Bool("normalize", true, "Normalize embeddings for cosine similarity")
+	)
+	flag.Parse()
+	if *question == "" {
+		log.Fatal("--q question prompt is required")
+	}
+
+	embedder := memory.AutoEmbedder()
+	pipeline := uploads.Pipeline{
+		Embedder:       embedder,
+		SimilarityMode: "cosine",
+		Normalize:      *normalize,
+		Middlewares:    []uploads.Middleware{uploads.PIIRedactor{}},
+	}
+
+	var chunks []uploads.DocumentChunk
+	if *pdfPath != "" {
+		f, err := os.Open(*pdfPath)
+		if err != nil {
+			log.Fatalf("open pdf: %v", err)
+		}
+		defer f.Close()
+		pdfChunks, err := (uploads.PDFChunker{}).Chunk(uploads.ReaderWithName{Name: filepath.Base(*pdfPath), Reader: f}, uploads.Source{Name: "pdf", URI: *pdfPath})
+		if err != nil {
+			log.Fatalf("chunk pdf: %v", err)
+		}
+		chunks = append(chunks, pdfChunks...)
+	}
+	if *repoPath != "" {
+		repoChunks, err := (uploads.CodeChunker{Root: *repoPath}).Chunk(uploads.ReaderWithName{}, uploads.Source{Name: "repo", URI: *repoPath})
+		if err != nil {
+			log.Fatalf("chunk repo: %v", err)
+		}
+		chunks = append(chunks, repoChunks...)
+	}
+	if len(chunks) == 0 {
+		log.Fatal("at least one source (--pdf or --repo) must be provided")
+	}
+
+	embedded, err := pipeline.Process(context.Background(), chunks)
+	if err != nil {
+		log.Fatalf("embed chunks: %v", err)
+	}
+	filtered := embedded[:0]
+	for _, res := range embedded {
+		if res.Err == nil {
+			filtered = append(filtered, res)
+		}
+	}
+	if len(filtered) == 0 {
+		log.Fatal("no embeddings generated from sources")
+	}
+
+	questionVec, err := embedder.Embed(context.Background(), *question)
+	if err != nil {
+		log.Fatalf("embed question: %v", err)
+	}
+	if *normalize {
+		uploads.NormalizeVector(questionVec)
+	}
+
+	sort.Slice(filtered, func(i, j int) bool {
+		return similarity(questionVec, filtered[i].Vector) > similarity(questionVec, filtered[j].Vector)
+	})
+
+	limit := *topK
+	if limit > len(filtered) {
+		limit = len(filtered)
+	}
+	for i := 0; i < limit; i++ {
+		res := filtered[i]
+		fmt.Printf("%d. score=%.4f source=%v id=%s\n", i+1, similarity(questionVec, res.Vector), res.Chunk.Metadata["source"], res.Chunk.ID)
+		fmt.Printf("   preview: %.160s\n", res.Chunk.Content)
+	}
+}
+
+func similarity(a []float32, b []float32) float64 {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	var sum float64
+	for i := 0; i < n; i++ {
+		sum += float64(a[i] * b[i])
+	}
+	return sum
+}

--- a/pkg/uploads/chunker_test.go
+++ b/pkg/uploads/chunker_test.go
@@ -1,0 +1,37 @@
+package uploads
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTextChunker(t *testing.T) {
+	chunker := TextChunker{MaxTokens: 4}
+	src := Source{Name: "notes", URI: "file://notes.txt"}
+	chunks, err := chunker.Chunk(ReaderWithName{Name: "notes.txt", Reader: strings.NewReader("one two three four five six")}, src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks got %d", len(chunks))
+	}
+	if chunks[0].Metadata["source"] != "notes" {
+		t.Fatalf("expected provenance metadata")
+	}
+}
+
+func TestMarkdownChunkerSections(t *testing.T) {
+	chunker := MarkdownChunker{MaxTokens: 10}
+	src := Source{Name: "doc"}
+	md := "# Heading\nBody line\n\n## Sub\nMore text"
+	chunks, err := chunker.Chunk(ReaderWithName{Name: "doc.md", Reader: strings.NewReader(md)}, src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks got %d", len(chunks))
+	}
+	if _, ok := chunks[0].Metadata["section_heading"]; !ok {
+		t.Fatalf("expected section heading metadata")
+	}
+}

--- a/pkg/uploads/code_chunker.go
+++ b/pkg/uploads/code_chunker.go
@@ -1,0 +1,164 @@
+package uploads
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CodeChunker walks a repository honoring a subset of .gitignore patterns and emits per-file chunks.
+type CodeChunker struct {
+	Root           string
+	MaxFileTokens  int
+	AdditionalMeta map[string]any
+}
+
+func (c CodeChunker) Chunk(_ ReaderWithName, src Source) ([]DocumentChunk, error) {
+	if c.Root == "" {
+		return nil, ErrUnsupported
+	}
+	max := c.MaxFileTokens
+	if max <= 0 {
+		max = 800
+	}
+	matcher := newIgnoreMatcher(filepath.Join(c.Root, ".gitignore"))
+
+	var chunks []DocumentChunk
+	err := filepath.WalkDir(c.Root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(c.Root, path)
+		if relErr != nil {
+			rel = path
+		}
+		if rel == "." {
+			rel = ""
+		}
+		if matcher != nil && matcher.Match(rel, d.IsDir()) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		content := string(data)
+		if strings.TrimSpace(content) == "" {
+			return nil
+		}
+		chunks = append(chunks, makeCodeChunks(rel, content, src, max, c.AdditionalMeta)...)
+		return nil
+	})
+	return chunks, err
+}
+
+func makeCodeChunks(path, content string, src Source, max int, extra map[string]any) []DocumentChunk {
+	lines := strings.Split(content, "\n")
+	var (
+		chunks     []DocumentChunk
+		builder    strings.Builder
+		tokenCount int
+		idx        int
+	)
+	emit := func() {
+		if builder.Len() == 0 {
+			return
+		}
+		meta := map[string]any{
+			"chunk_index": idx,
+			"path":        path,
+		}
+		for k, v := range extra {
+			meta[k] = v
+		}
+		chunk := DocumentChunk{
+			ID:       chunkID(path, idx),
+			Content:  builder.String(),
+			Metadata: meta,
+		}
+		chunk = chunk.WithProvenance(src.Name, src.URI, 0, src.Version)
+		chunks = append(chunks, chunk)
+		idx++
+		builder.Reset()
+		tokenCount = 0
+	}
+
+	for _, line := range lines {
+		estimated := estimateTokens(line)
+		if tokenCount+estimated > max && builder.Len() > 0 {
+			emit()
+		}
+		builder.WriteString(line)
+		builder.WriteByte('\n')
+		tokenCount += estimated
+	}
+	emit()
+	return chunks
+}
+
+type ignoreMatcher struct {
+	patterns []string
+}
+
+func newIgnoreMatcher(path string) *ignoreMatcher {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	lines := strings.Split(string(data), "\n")
+	var patterns []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		patterns = append(patterns, line)
+	}
+	if len(patterns) == 0 {
+		return nil
+	}
+	return &ignoreMatcher{patterns: patterns}
+}
+
+func (m *ignoreMatcher) Match(path string, dir bool) bool {
+	if m == nil {
+		return false
+	}
+	normalized := filepath.ToSlash(path)
+	for _, pattern := range m.patterns {
+		pat := pattern
+		negate := false
+		if strings.HasPrefix(pat, "!") {
+			negate = true
+			pat = strings.TrimPrefix(pat, "!")
+		}
+		if dir && !strings.HasSuffix(pat, "/") {
+			pat += "/"
+		}
+		if strings.HasPrefix(pat, "/") {
+			pat = strings.TrimPrefix(pat, "/")
+		}
+		matched, _ := filepath.Match(pat, normalized)
+		if !matched && strings.Contains(pat, "/") {
+			// allow contains matches for directory patterns
+			matched = strings.HasPrefix(normalized, pat)
+		}
+		if matched {
+			if negate {
+				return false
+			}
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/uploads/document.go
+++ b/pkg/uploads/document.go
@@ -1,0 +1,72 @@
+package uploads
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"time"
+)
+
+// DocumentChunk represents a single chunk of text with rich provenance metadata.
+type DocumentChunk struct {
+	ID       string
+	Content  string
+	Metadata map[string]any
+}
+
+// WithProvenance ensures provenance fields exist on the metadata map.
+func (c DocumentChunk) WithProvenance(source, uri string, page int, version string) DocumentChunk {
+	meta := make(map[string]any, len(c.Metadata)+5)
+	for k, v := range c.Metadata {
+		meta[k] = v
+	}
+	if source != "" {
+		meta["source"] = source
+	}
+	if uri != "" {
+		meta["uri"] = uri
+	}
+	if page > 0 {
+		meta["page"] = page
+	}
+	if version != "" {
+		meta["version"] = version
+	}
+	if _, ok := meta["ingested_at"]; !ok {
+		meta["ingested_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	if _, ok := meta["checksum"]; !ok {
+		meta["checksum"] = checksum(c.Content)
+	}
+	c.Metadata = meta
+	return c
+}
+
+// checksum calculates a deterministic checksum for provenance tracking.
+func checksum(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:])
+}
+
+// Source describes the logical origin of an upload.
+type Source struct {
+	Name       string
+	URI        string
+	Version    string
+	Additional map[string]any
+}
+
+// ReaderWithName couples an io.Reader with an optional filename for chunkers.
+type ReaderWithName struct {
+	Name   string
+	Reader io.Reader
+}
+
+// Chunker is implemented by upload chunkers (text, markdown, pdf, code, ...).
+type Chunker interface {
+	Chunk(reader ReaderWithName, src Source) ([]DocumentChunk, error)
+}
+
+// ErrUnsupported is returned when a chunker cannot handle a file.
+var ErrUnsupported = fmt.Errorf("uploads: unsupported format")

--- a/pkg/uploads/markdown_chunker.go
+++ b/pkg/uploads/markdown_chunker.go
@@ -1,0 +1,91 @@
+package uploads
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"strings"
+)
+
+var headingRegexp = regexp.MustCompile(`^(#{1,6})\s+(.*)$`)
+
+// MarkdownChunker groups text under headings while respecting the configured token budget.
+type MarkdownChunker struct {
+	MaxTokens int
+}
+
+func (m MarkdownChunker) Chunk(reader ReaderWithName, src Source) ([]DocumentChunk, error) {
+	max := m.MaxTokens
+	if max <= 0 {
+		max = 400
+	}
+	buf := new(strings.Builder)
+	if _, err := io.Copy(buf, reader.Reader); err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(strings.NewReader(buf.String()))
+
+	var (
+		chunks     []DocumentChunk
+		builder    strings.Builder
+		heading    string
+		idx        int
+		tokenCount int
+	)
+
+	emit := func() {
+		if builder.Len() == 0 {
+			return
+		}
+		chunk := DocumentChunk{
+			ID:      chunkID(reader.Name, idx),
+			Content: strings.TrimSpace(builder.String()),
+			Metadata: map[string]any{
+				"chunk_index": idx,
+			},
+		}
+		if heading != "" {
+			chunk.Metadata["section_heading"] = heading
+		}
+		chunk = chunk.WithProvenance(src.Name, src.URI, 0, src.Version)
+		for k, v := range src.Additional {
+			chunk.Metadata[k] = v
+		}
+		chunks = append(chunks, chunk)
+		idx++
+		builder.Reset()
+		heading = ""
+		tokenCount = 0
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if matches := headingRegexp.FindStringSubmatch(line); len(matches) == 3 {
+			if builder.Len() > 0 {
+				emit()
+			}
+			heading = strings.TrimSpace(matches[2])
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			if builder.Len() > 0 {
+				builder.WriteString("\n")
+			}
+			continue
+		}
+		estimated := estimateTokens(line)
+		if tokenCount+estimated > max && builder.Len() > 0 {
+			emit()
+		}
+		if builder.Len() > 0 {
+			builder.WriteString("\n")
+		}
+		builder.WriteString(line)
+		tokenCount += estimated
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	emit()
+	return chunks, nil
+}

--- a/pkg/uploads/norm.go
+++ b/pkg/uploads/norm.go
@@ -1,0 +1,6 @@
+package uploads
+
+// NormalizeVector exposes the internal normalisation helper for examples/tests.
+func NormalizeVector(vec []float32) {
+	normalize(vec)
+}

--- a/pkg/uploads/pdf_chunker.go
+++ b/pkg/uploads/pdf_chunker.go
@@ -1,0 +1,104 @@
+package uploads
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+)
+
+var (
+	textObjectPattern = regexp.MustCompile(`(?s)\((.*?)\)\s+(?:Tj|TJ)`)
+	pageSplitPattern  = regexp.MustCompile(`(?i)\n\s*endstream`)
+)
+
+// PDFChunker extracts best-effort page-level chunks using a lightweight parser.
+type PDFChunker struct{}
+
+func (p PDFChunker) Chunk(reader ReaderWithName, src Source) ([]DocumentChunk, error) {
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, reader.Reader); err != nil {
+		return nil, err
+	}
+	if buf.Len() == 0 {
+		return nil, nil
+	}
+	pages := pageSplitPattern.Split(buf.String(), -1)
+	var chunks []DocumentChunk
+	for idx, raw := range pages {
+		text := extractText(raw)
+		if text == "" {
+			continue
+		}
+		chunk := DocumentChunk{
+			ID:      chunkID(reader.Name, idx),
+			Content: text,
+			Metadata: map[string]any{
+				"chunk_index": idx,
+			},
+		}
+		chunk = chunk.WithProvenance(src.Name, src.URI, idx+1, src.Version)
+		for k, v := range src.Additional {
+			chunk.Metadata[k] = v
+		}
+		chunks = append(chunks, chunk)
+	}
+	if len(chunks) == 0 {
+		return nil, fmt.Errorf("pdf chunker: unable to extract text")
+	}
+	return chunks, nil
+}
+
+func extractText(raw string) string {
+	matches := textObjectPattern.FindAllStringSubmatch(raw, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+	var buf bytes.Buffer
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		text := decodePDFString(m[1])
+		if text == "" {
+			continue
+		}
+		if buf.Len() > 0 {
+			buf.WriteByte(' ')
+		}
+		buf.WriteString(text)
+	}
+	return normalizeWhitespace(buf.String())
+}
+
+func decodePDFString(s string) string {
+	var buf bytes.Buffer
+	escaped := false
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if escaped {
+			switch ch {
+			case 'n':
+				buf.WriteByte('\n')
+			case 'r':
+				buf.WriteByte('\r')
+			case 't':
+				buf.WriteByte('\t')
+			case 'b':
+				buf.WriteByte('\b')
+			case 'f':
+				buf.WriteByte('\f')
+			default:
+				buf.WriteByte(ch)
+			}
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		buf.WriteByte(ch)
+	}
+	return buf.String()
+}

--- a/pkg/uploads/pii_middleware.go
+++ b/pkg/uploads/pii_middleware.go
@@ -1,0 +1,33 @@
+package uploads
+
+import (
+	"context"
+	"regexp"
+)
+
+var (
+	emailRegexp = regexp.MustCompile(`(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}`)
+	phoneRegexp = regexp.MustCompile(`(?i)\b(?:\+?\d[\d -]{7,}\d)`)
+)
+
+// PIIRedactor removes common PII patterns before embedding content.
+type PIIRedactor struct {
+	Replacement string
+}
+
+func (r PIIRedactor) Process(_ context.Context, chunk *DocumentChunk) error {
+	if chunk == nil {
+		return nil
+	}
+	replacement := r.Replacement
+	if replacement == "" {
+		replacement = "[redacted]"
+	}
+	chunk.Content = emailRegexp.ReplaceAllString(chunk.Content, replacement)
+	chunk.Content = phoneRegexp.ReplaceAllString(chunk.Content, replacement)
+	if chunk.Metadata == nil {
+		chunk.Metadata = map[string]any{}
+	}
+	chunk.Metadata["pii_redacted"] = true
+	return nil
+}

--- a/pkg/uploads/pipeline.go
+++ b/pkg/uploads/pipeline.go
@@ -1,0 +1,210 @@
+package uploads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/memory"
+)
+
+// EmbeddedChunk couples a chunk with its embedding vector.
+type EmbeddedChunk struct {
+	Chunk    DocumentChunk
+	Vector   []float32
+	Attempts int
+	Err      error
+	Duration time.Duration
+}
+
+// Pipeline orchestrates chunk processing, content safety middleware, and embedding.
+type Pipeline struct {
+	Embedder       memory.Embedder
+	Middlewares    []Middleware
+	BatchSize      int
+	WorkerCount    int
+	ExpectedDims   int
+	Normalize      bool
+	SimilarityMode string
+	RetryOptions   RetryOptions
+	Metrics        Metrics
+}
+
+// Middleware can mutate a chunk before it is embedded.
+type Middleware interface {
+	Process(ctx context.Context, chunk *DocumentChunk) error
+}
+
+// MiddlewareFunc converts a function into Middleware.
+type MiddlewareFunc func(ctx context.Context, chunk *DocumentChunk) error
+
+func (f MiddlewareFunc) Process(ctx context.Context, chunk *DocumentChunk) error {
+	return f(ctx, chunk)
+}
+
+// Metrics is a light-weight interface so callers can instrument the pipeline.
+type Metrics interface {
+	ObserveQueueDepth(depth int)
+	RecordEmbedding(duration time.Duration, ok bool)
+}
+
+// RetryOptions control the retry behaviour when embedding fails.
+type RetryOptions struct {
+	MaxAttempts int
+	Jitter      time.Duration
+	BaseDelay   time.Duration
+}
+
+// Process embeds the provided chunks using a bounded worker pool.
+func (p Pipeline) Process(ctx context.Context, chunks []DocumentChunk) ([]EmbeddedChunk, error) {
+	if p.Embedder == nil {
+		return nil, errors.New("uploads pipeline requires an embedder")
+	}
+	if p.WorkerCount <= 0 {
+		p.WorkerCount = 4
+	}
+	if p.BatchSize <= 0 {
+		p.BatchSize = 32
+	}
+	if p.RetryOptions.MaxAttempts <= 0 {
+		p.RetryOptions.MaxAttempts = 3
+	}
+	if p.RetryOptions.BaseDelay <= 0 {
+		p.RetryOptions.BaseDelay = 200 * time.Millisecond
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	input := make(chan DocumentChunk, p.BatchSize)
+	output := make(chan EmbeddedChunk, len(chunks))
+	var wg sync.WaitGroup
+
+	for i := 0; i < p.WorkerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for chunk := range input {
+				result := p.embedWithRetry(ctx, chunk)
+				select {
+				case <-ctx.Done():
+					return
+				case output <- result:
+				}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(input)
+		for _, chunk := range chunks {
+			if err := p.applyMiddleware(ctx, &chunk); err != nil {
+				output <- EmbeddedChunk{Chunk: chunk, Err: err}
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case input <- chunk:
+				if p.Metrics != nil {
+					p.Metrics.ObserveQueueDepth(len(input))
+				}
+			}
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		close(output)
+	}()
+
+	results := make([]EmbeddedChunk, 0, len(chunks))
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case res, ok := <-output:
+			if !ok {
+				return results, nil
+			}
+			if res.Err == nil {
+				if p.ExpectedDims > 0 && len(res.Vector) != p.ExpectedDims {
+					res.Err = fmt.Errorf("embedding dimension mismatch: got %d expected %d", len(res.Vector), p.ExpectedDims)
+				}
+				if res.Err == nil && p.Normalize && p.SimilarityMode == "cosine" {
+					normalize(res.Vector)
+				}
+			}
+			results = append(results, res)
+		}
+	}
+}
+
+func (p Pipeline) applyMiddleware(ctx context.Context, chunk *DocumentChunk) error {
+	for _, mw := range p.Middlewares {
+		if mw == nil {
+			continue
+		}
+		if err := mw.Process(ctx, chunk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p Pipeline) embedWithRetry(ctx context.Context, chunk DocumentChunk) EmbeddedChunk {
+	start := time.Now()
+	attempts := 0
+	for {
+		if ctx.Err() != nil {
+			return EmbeddedChunk{Chunk: chunk, Attempts: attempts, Err: ctx.Err()}
+		}
+		attempts++
+		vec, err := p.Embedder.Embed(ctx, chunk.Content)
+		duration := time.Since(start)
+		if err == nil && len(vec) > 0 {
+			if p.Metrics != nil {
+				p.Metrics.RecordEmbedding(duration, true)
+			}
+			return EmbeddedChunk{Chunk: chunk, Vector: vec, Attempts: attempts, Duration: duration}
+		}
+		if attempts >= p.RetryOptions.MaxAttempts {
+			if p.Metrics != nil {
+				p.Metrics.RecordEmbedding(duration, false)
+			}
+			if err == nil {
+				err = fmt.Errorf("empty embedding for chunk %s", chunk.ID)
+			}
+			return EmbeddedChunk{Chunk: chunk, Attempts: attempts, Err: err, Duration: duration}
+		}
+		// jittered backoff
+		delay := p.RetryOptions.BaseDelay * time.Duration(attempts)
+		if p.RetryOptions.Jitter > 0 {
+			delay += time.Duration(rand.Int63n(int64(p.RetryOptions.Jitter)))
+		}
+		select {
+		case <-ctx.Done():
+			return EmbeddedChunk{Chunk: chunk, Attempts: attempts, Err: ctx.Err(), Duration: duration}
+		case <-time.After(delay):
+		}
+	}
+}
+
+func normalize(vec []float32) {
+	var sum float64
+	for _, v := range vec {
+		sum += float64(v * v)
+	}
+	magnitude := math.Sqrt(sum)
+	if magnitude == 0 {
+		return
+	}
+	inv := 1.0 / magnitude
+	for i := range vec {
+		vec[i] = float32(float64(vec[i]) * inv)
+	}
+}

--- a/pkg/uploads/pipeline_test.go
+++ b/pkg/uploads/pipeline_test.go
@@ -1,0 +1,93 @@
+package uploads
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeEmbedder struct {
+	err     error
+	vector  []float32
+	latency time.Duration
+	calls   int
+}
+
+func (f *fakeEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	f.calls++
+	if f.latency > 0 {
+		time.Sleep(f.latency)
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.vector, nil
+}
+
+type fakeMetrics struct {
+	queue []int
+	ok    int
+	fail  int
+}
+
+func (m *fakeMetrics) ObserveQueueDepth(depth int) {
+	m.queue = append(m.queue, depth)
+}
+
+func (m *fakeMetrics) RecordEmbedding(_ time.Duration, ok bool) {
+	if ok {
+		m.ok++
+	} else {
+		m.fail++
+	}
+}
+
+func TestPipelineProcess(t *testing.T) {
+	embedder := &fakeEmbedder{vector: []float32{1, 2, 3}}
+	pipeline := Pipeline{
+		Embedder:       embedder,
+		WorkerCount:    2,
+		ExpectedDims:   3,
+		Normalize:      true,
+		SimilarityMode: "cosine",
+		Metrics:        &fakeMetrics{},
+	}
+
+	chunks := []DocumentChunk{{ID: "1", Content: "hello"}, {ID: "2", Content: "world"}}
+	results, err := pipeline.Process(context.Background(), chunks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != len(chunks) {
+		t.Fatalf("expected %d results got %d", len(chunks), len(results))
+	}
+	for _, res := range results {
+		if res.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", res.Err)
+		}
+		if len(res.Vector) != 3 {
+			t.Fatalf("unexpected vector dims: %d", len(res.Vector))
+		}
+	}
+}
+
+func TestPipelineRetry(t *testing.T) {
+	embedder := &fakeEmbedder{err: errors.New("boom"), vector: []float32{1}}
+	pipeline := Pipeline{Embedder: embedder, RetryOptions: RetryOptions{MaxAttempts: 2, BaseDelay: time.Millisecond}}
+
+	chunks := []DocumentChunk{{ID: "1", Content: "retry"}}
+	results, err := pipeline.Process(context.Background(), chunks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result got %d", len(results))
+	}
+	if results[0].Err == nil {
+		t.Fatalf("expected error result")
+	}
+	if embedder.calls != 2 {
+		t.Fatalf("expected 2 calls got %d", embedder.calls)
+	}
+}

--- a/pkg/uploads/text_chunker.go
+++ b/pkg/uploads/text_chunker.go
@@ -1,0 +1,121 @@
+package uploads
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// TextChunker splits plain text into roughly-even chunks based on word boundaries.
+type TextChunker struct {
+	MaxTokens int
+}
+
+func (t TextChunker) Chunk(reader ReaderWithName, src Source) ([]DocumentChunk, error) {
+	max := t.MaxTokens
+	if max <= 0 {
+		max = 512
+	}
+	buf := new(strings.Builder)
+	if _, err := io.Copy(buf, reader.Reader); err != nil {
+		return nil, err
+	}
+	text := strings.TrimSpace(buf.String())
+	if text == "" {
+		return nil, nil
+	}
+	return chunkByWords(text, max, reader.Name, src)
+}
+
+func chunkByWords(text string, maxTokens int, name string, src Source) ([]DocumentChunk, error) {
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	scanner.Split(bufio.ScanWords)
+
+	var (
+		chunks  []DocumentChunk
+		builder strings.Builder
+		count   int
+		idx     int
+	)
+
+	emit := func() {
+		if builder.Len() == 0 {
+			return
+		}
+		chunk := makeChunk(idx, builder.String(), name, src)
+		chunks = append(chunks, chunk)
+		idx++
+		builder.Reset()
+		count = 0
+	}
+
+	for scanner.Scan() {
+		word := scanner.Text()
+		wordTokens := estimateTokens(word)
+		if count+wordTokens > maxTokens && builder.Len() > 0 {
+			emit()
+		}
+		if builder.Len() > 0 {
+			builder.WriteByte(' ')
+		}
+		builder.WriteString(word)
+		count += wordTokens
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	emit()
+	return chunks, nil
+}
+
+func estimateTokens(word string) int {
+	if word == "" {
+		return 0
+	}
+	runes := utf8.RuneCountInString(word)
+	switch {
+	case runes <= 4:
+		return 1
+	case runes <= 8:
+		return 2
+	case runes <= 16:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func makeChunk(idx int, text, name string, src Source) DocumentChunk {
+	chunk := DocumentChunk{
+		ID:      chunkID(name, idx),
+		Content: strings.TrimSpace(text),
+		Metadata: map[string]any{
+			"chunk_index": idx,
+		},
+	}
+	chunk = chunk.WithProvenance(src.Name, src.URI, 0, src.Version)
+	for k, v := range src.Additional {
+		chunk.Metadata[k] = v
+	}
+	return chunk
+}
+
+func chunkID(name string, idx int) string {
+	if name == "" {
+		return fmt.Sprintf("chunk-%d", idx)
+	}
+	sanitized := strings.ReplaceAll(strings.TrimSpace(name), " ", "_")
+	sanitized = strings.ReplaceAll(sanitized, "/", "_")
+	if sanitized == "" {
+		sanitized = "chunk"
+	}
+	return fmt.Sprintf("%s#%d", sanitized, idx)
+}
+
+// Sequence helper for deterministic chunk ordering.
+func sequenceID(base string, idx int) string {
+	return fmt.Sprintf("%s-%s", base, strconv.Itoa(idx))
+}

--- a/pkg/uploads/util.go
+++ b/pkg/uploads/util.go
@@ -1,0 +1,16 @@
+package uploads
+
+import (
+	"regexp"
+	"strings"
+)
+
+var whitespaceRegexp = regexp.MustCompile(`\s+`)
+
+func normalizeWhitespace(text string) string {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return ""
+	}
+	return whitespaceRegexp.ReplaceAllString(trimmed, " ")
+}


### PR DESCRIPTION
## Summary
- add pkg/uploads with text/markdown/PDF/code chunkers, provenance metadata, and an embedding pipeline with middleware and backpressure-aware workers
- expose optional PII redaction, normalization helper, and provenance tracking helpers for ingestion flows
- add runnable examples for ingesting PDFs, repositories, and querying blended sources plus updated README documentation

## Testing
- `go test ./...`
