### PR TITLE
Refactor memory package into modular subpackages

### DIFF
--- a/pkg/memory/embed/claude.go
+++ b/pkg/memory/embed/claude.go
@@ -1,4 +1,4 @@
-package memory
+package embed
 
 import (
 	"bytes"

--- a/pkg/memory/embed/embed.go
+++ b/pkg/memory/embed/embed.go
@@ -1,4 +1,4 @@
-package memory
+package embed
 
 import (
 	"context"

--- a/pkg/memory/embed/ollama.go
+++ b/pkg/memory/embed/ollama.go
@@ -1,4 +1,4 @@
-package memory
+package embed
 
 import (
 	"context"

--- a/pkg/memory/embed/openai.go
+++ b/pkg/memory/embed/openai.go
@@ -1,4 +1,4 @@
-package memory
+package embed
 
 import (
 	"context"

--- a/pkg/memory/embed/vertex.go
+++ b/pkg/memory/embed/vertex.go
@@ -1,4 +1,4 @@
-package memory
+package embed
 
 import (
 	"context"

--- a/pkg/memory/engine/engine_bench_test.go
+++ b/pkg/memory/engine/engine_bench_test.go
@@ -1,16 +1,19 @@
-package memory
+package engine
 
 import (
 	"context"
 	"fmt"
 	"testing"
 	"time"
+
+	embedpkg "github.com/Raezil/go-agent-development-kit/pkg/memory/embed"
+	storepkg "github.com/Raezil/go-agent-development-kit/pkg/memory/store"
 )
 
 func BenchmarkEngineRetrieve(b *testing.B) {
-	store := NewInMemoryStore()
+	store := storepkg.NewInMemoryStore()
 	opts := Options{HalfLife: time.Hour, TTL: 720 * time.Hour}
-	engine := NewEngine(store, opts).WithEmbedder(DummyEmbedder{})
+	engine := NewEngine(store, opts).WithEmbedder(embedpkg.DummyEmbedder{})
 	ctx := context.Background()
 
 	for i := 0; i < 500; i++ {

--- a/pkg/memory/engine/metrics.go
+++ b/pkg/memory/engine/metrics.go
@@ -1,4 +1,4 @@
-package memory
+package engine
 
 import "sync/atomic"
 

--- a/pkg/memory/engine/options.go
+++ b/pkg/memory/engine/options.go
@@ -1,4 +1,4 @@
-package memory
+package engine
 
 import "time"
 

--- a/pkg/memory/engine/summarizer.go
+++ b/pkg/memory/engine/summarizer.go
@@ -1,19 +1,21 @@
-package memory
+package engine
 
 import (
 	"context"
 	"strings"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/memory/model"
 )
 
 // Summarizer abstracts cluster summarization backends (LLMs or heuristics).
 type Summarizer interface {
-	Summarize(ctx context.Context, cluster []MemoryRecord) (string, error)
+	Summarize(ctx context.Context, cluster []model.MemoryRecord) (string, error)
 }
 
 // HeuristicSummarizer produces deterministic summaries suitable for tests.
 type HeuristicSummarizer struct{}
 
-func (HeuristicSummarizer) Summarize(_ context.Context, cluster []MemoryRecord) (string, error) {
+func (HeuristicSummarizer) Summarize(_ context.Context, cluster []model.MemoryRecord) (string, error) {
 	if len(cluster) == 0 {
 		return "", nil
 	}

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -1,0 +1,78 @@
+package memory
+
+import (
+	embedpkg "github.com/Raezil/go-agent-development-kit/pkg/memory/embed"
+	memengine "github.com/Raezil/go-agent-development-kit/pkg/memory/engine"
+	"github.com/Raezil/go-agent-development-kit/pkg/memory/model"
+	sessionpkg "github.com/Raezil/go-agent-development-kit/pkg/memory/session"
+	storepkg "github.com/Raezil/go-agent-development-kit/pkg/memory/store"
+)
+
+// Type aliases preserving the original public API.
+type (
+	Engine              = memengine.Engine
+	Options             = memengine.Options
+	ScoreWeights        = memengine.ScoreWeights
+	Metrics             = memengine.Metrics
+	MetricsSnapshot     = memengine.MetricsSnapshot
+	Summarizer          = memengine.Summarizer
+	HeuristicSummarizer = memengine.HeuristicSummarizer
+
+	MemoryRecord = model.MemoryRecord
+	GraphEdge    = model.GraphEdge
+	EdgeType     = model.EdgeType
+
+	MemoryBank    = sessionpkg.MemoryBank
+	SessionMemory = sessionpkg.SessionMemory
+	SpaceRegistry = sessionpkg.SpaceRegistry
+	SpaceRole     = sessionpkg.SpaceRole
+	Space         = sessionpkg.Space
+	SharedSession = sessionpkg.SharedSession
+
+	VectorStore       = storepkg.VectorStore
+	SchemaInitializer = storepkg.SchemaInitializer
+	GraphStore        = storepkg.GraphStore
+
+	InMemoryStore           = storepkg.InMemoryStore
+	PostgresStore           = storepkg.PostgresStore
+	QdrantStore             = storepkg.QdrantStore
+	Distance                = storepkg.Distance
+	CreateCollectionRequest = storepkg.CreateCollectionRequest
+
+	Embedder      = embedpkg.Embedder
+	DummyEmbedder = embedpkg.DummyEmbedder
+)
+
+const (
+	EdgeFollows     = model.EdgeFollows
+	EdgeExplains    = model.EdgeExplains
+	EdgeContradicts = model.EdgeContradicts
+	EdgeDerivedFrom = model.EdgeDerivedFrom
+
+	SpaceRoleReader = sessionpkg.SpaceRoleReader
+	SpaceRoleWriter = sessionpkg.SpaceRoleWriter
+	SpaceRoleAdmin  = sessionpkg.SpaceRoleAdmin
+)
+
+var (
+	ErrNotSupported = embedpkg.ErrNotSupported
+
+	NewEngine              = memengine.NewEngine
+	DefaultOptions         = memengine.DefaultOptions
+	NewMemoryBank          = sessionpkg.NewMemoryBank
+	NewMemoryBankWithStore = sessionpkg.NewMemoryBankWithStore
+	NewSessionMemory       = sessionpkg.NewSessionMemory
+	NewSharedSession       = sessionpkg.NewSharedSession
+	NewSpaceRegistry       = sessionpkg.NewSpaceRegistry
+
+	AutoEmbedder        = embedpkg.AutoEmbedder
+	DummyEmbedding      = embedpkg.DummyEmbedding
+	NewOpenAIEmbedder   = embedpkg.NewOpenAIEmbedder
+	NewVertexAIEmbedder = embedpkg.NewVertexAIEmbedder
+	NewOllamaEmbedder   = embedpkg.NewOllamaEmbedder
+	NewClaudeEmbedder   = embedpkg.NewClaudeEmbedder
+
+	NewInMemoryStore = storepkg.NewInMemoryStore
+	NewPostgresStore = storepkg.NewPostgresStore
+	NewQdrantStore   = storepkg.NewQdrantStore
+)

--- a/pkg/memory/memory_test.go
+++ b/pkg/memory/memory_test.go
@@ -1,6 +1,9 @@
 package memory
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestDummyEmbeddingDeterministic(t *testing.T) {
 	first := DummyEmbedding("hello")
@@ -23,7 +26,10 @@ func TestAddShortTermTrimsToLimit(t *testing.T) {
 		sm.AddShortTerm("session", content, "{}", nil)
 	}
 
-	records := sm.shortTerm["session"]
+	records, err := sm.RetrieveContext(context.Background(), "session", "", 10)
+	if err != nil {
+		t.Fatalf("retrieve context: %v", err)
+	}
 	if len(records) != 3 {
 		t.Fatalf("expected 3 records retained, got %d", len(records))
 	}
@@ -31,19 +37,6 @@ func TestAddShortTermTrimsToLimit(t *testing.T) {
 	for i, rec := range records {
 		if rec.Content != expected[i] {
 			t.Fatalf("unexpected record %d content: %q", i, rec.Content)
-		}
-	}
-}
-
-func TestTrimJSON(t *testing.T) {
-	cases := map[string]string{
-		"[1,2,3]":     "1,2,3",
-		"[[nested]]":  "nested",
-		"no brackets": "no brackets",
-	}
-	for input, want := range cases {
-		if got := trimJSON(input); got != want {
-			t.Fatalf("trimJSON(%q) = %q, want %q", input, got, want)
 		}
 	}
 }

--- a/pkg/memory/model/graph.go
+++ b/pkg/memory/model/graph.go
@@ -1,4 +1,4 @@
-package memory
+package model
 
 import (
 	"encoding/json"
@@ -42,7 +42,7 @@ func (g GraphEdge) Validate() error {
 }
 
 // sanitizeGraphEdges normalizes the metadata map and extracts the edge list.
-func sanitizeGraphEdges(meta map[string]any) []GraphEdge {
+func SanitizeGraphEdges(meta map[string]any) []GraphEdge {
 	if meta == nil {
 		return nil
 	}
@@ -50,7 +50,7 @@ func sanitizeGraphEdges(meta map[string]any) []GraphEdge {
 	if !ok {
 		return nil
 	}
-	edges := decodeGraphEdges(raw)
+	edges := DecodeGraphEdges(raw)
 	sanitized := make([]GraphEdge, 0, len(edges))
 	for _, edge := range edges {
 		if err := edge.Validate(); err != nil {
@@ -67,7 +67,7 @@ func sanitizeGraphEdges(meta map[string]any) []GraphEdge {
 }
 
 // decodeGraphEdges attempts to coerce arbitrary metadata into []GraphEdge.
-func decodeGraphEdges(raw any) []GraphEdge {
+func DecodeGraphEdges(raw any) []GraphEdge {
 	switch v := raw.(type) {
 	case []GraphEdge:
 		return v
@@ -142,7 +142,7 @@ func numericToInt(v any) int64 {
 	return 0
 }
 
-func validGraphEdges(meta map[string]any) []GraphEdge {
+func ValidGraphEdges(meta map[string]any) []GraphEdge {
 	if meta == nil {
 		return nil
 	}
@@ -150,7 +150,7 @@ func validGraphEdges(meta map[string]any) []GraphEdge {
 	if !ok {
 		return nil
 	}
-	edges := decodeGraphEdges(raw)
+	edges := DecodeGraphEdges(raw)
 	if len(edges) == 0 {
 		return nil
 	}

--- a/pkg/memory/model/metadata.go
+++ b/pkg/memory/model/metadata.go
@@ -1,20 +1,20 @@
-package memory
+package model
 
 import (
 	"encoding/json"
 	"time"
 )
 
-func normalizeMetadata(meta map[string]any, fallback time.Time) (importance float64, source, summary string, lastEmbedded time.Time, jsonString string) {
-	meta = cloneMetadata(meta)
-	importance = floatFromAny(meta["importance"])
-	source = stringFromAny(meta["source"])
-	summary = stringFromAny(meta["summary"])
-	lastEmbedded = timeFromAny(meta["last_embedded"])
-	if space := stringFromAny(meta["space"]); space != "" {
+func NormalizeMetadata(meta map[string]any, fallback time.Time) (importance float64, source, summary string, lastEmbedded time.Time, jsonString string) {
+	meta = CloneMetadata(meta)
+	importance = FloatFromAny(meta["importance"])
+	source = StringFromAny(meta["source"])
+	summary = StringFromAny(meta["summary"])
+	lastEmbedded = TimeFromAny(meta["last_embedded"])
+	if space := StringFromAny(meta["space"]); space != "" {
 		meta["space"] = space
 	}
-	edges := sanitizeGraphEdges(meta)
+	edges := SanitizeGraphEdges(meta)
 	if lastEmbedded.IsZero() {
 		if fallback.IsZero() {
 			fallback = time.Now().UTC()
@@ -33,7 +33,7 @@ func normalizeMetadata(meta map[string]any, fallback time.Time) (importance floa
 	return
 }
 
-func cloneMetadata(meta map[string]any) map[string]any {
+func CloneMetadata(meta map[string]any) map[string]any {
 	if meta == nil {
 		return map[string]any{}
 	}
@@ -44,7 +44,7 @@ func cloneMetadata(meta map[string]any) map[string]any {
 	return cp
 }
 
-func floatFromAny(v any) float64 {
+func FloatFromAny(v any) float64 {
 	switch t := v.(type) {
 	case float64:
 		return t
@@ -66,7 +66,7 @@ func floatFromAny(v any) float64 {
 	return 0
 }
 
-func stringFromAny(v any) string {
+func StringFromAny(v any) string {
 	if v == nil {
 		return ""
 	}
@@ -81,7 +81,7 @@ func stringFromAny(v any) string {
 	return string(b)
 }
 
-func timeFromAny(v any) time.Time {
+func TimeFromAny(v any) time.Time {
 	switch t := v.(type) {
 	case time.Time:
 		return t
@@ -94,7 +94,7 @@ func timeFromAny(v any) time.Time {
 	return time.Time{}
 }
 
-func decodeMetadata(metadata string) map[string]any {
+func DecodeMetadata(metadata string) map[string]any {
 	if metadata == "" {
 		return map[string]any{}
 	}
@@ -105,30 +105,30 @@ func decodeMetadata(metadata string) map[string]any {
 	return meta
 }
 
-func hydrateRecordFromMetadata(rec *MemoryRecord, meta map[string]any) {
+func HydrateRecordFromMetadata(rec *MemoryRecord, meta map[string]any) {
 	if rec == nil {
 		return
 	}
 	if rec.Importance == 0 {
-		rec.Importance = floatFromAny(meta["importance"])
+		rec.Importance = FloatFromAny(meta["importance"])
 	}
 	if rec.Source == "" {
-		rec.Source = stringFromAny(meta["source"])
+		rec.Source = StringFromAny(meta["source"])
 	}
 	if rec.Summary == "" {
-		rec.Summary = stringFromAny(meta["summary"])
+		rec.Summary = StringFromAny(meta["summary"])
 	}
 	if rec.LastEmbedded.IsZero() {
-		if ts := timeFromAny(meta["last_embedded"]); !ts.IsZero() {
+		if ts := TimeFromAny(meta["last_embedded"]); !ts.IsZero() {
 			rec.LastEmbedded = ts
 		}
 	}
 	if rec.Space == "" {
-		if space := stringFromAny(meta["space"]); space != "" {
+		if space := StringFromAny(meta["space"]); space != "" {
 			rec.Space = space
 		}
 	}
 	if len(rec.GraphEdges) == 0 {
-		rec.GraphEdges = validGraphEdges(meta)
+		rec.GraphEdges = ValidGraphEdges(meta)
 	}
 }

--- a/pkg/memory/model/record.go
+++ b/pkg/memory/model/record.go
@@ -1,0 +1,21 @@
+package model
+
+import "time"
+
+// MemoryRecord represents a persisted memory entry in the vector store.
+type MemoryRecord struct {
+	ID            int64       `json:"id"`
+	SessionID     string      `json:"session_id"`
+	Space         string      `json:"space"`
+	Content       string      `json:"content"`
+	Metadata      string      `json:"metadata"`
+	Embedding     []float32   `json:"embedding"`
+	Score         float64     `json:"score"`
+	Importance    float64     `json:"importance"`
+	Source        string      `json:"source"`
+	Summary       string      `json:"summary"`
+	CreatedAt     time.Time   `json:"created_at"`
+	LastEmbedded  time.Time   `json:"last_embedded"`
+	WeightedScore float64     `json:"weighted_score"`
+	GraphEdges    []GraphEdge `json:"graph_edges"`
+}

--- a/pkg/memory/model/similarity.go
+++ b/pkg/memory/model/similarity.go
@@ -1,0 +1,24 @@
+package model
+
+import "math"
+
+// CosineSimilarity computes the cosine similarity between two vectors.
+func CosineSimilarity(a, b []float32) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	var dot, normA, normB float64
+	length := len(a)
+	if len(b) < length {
+		length = len(b)
+	}
+	for i := 0; i < length; i++ {
+		dot += float64(a[i]) * float64(b[i])
+		normA += float64(a[i]) * float64(a[i])
+		normB += float64(b[i]) * float64(b[i])
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}

--- a/pkg/memory/session/spaces.go
+++ b/pkg/memory/session/spaces.go
@@ -1,4 +1,4 @@
-package memory
+package session
 
 import (
 	"errors"

--- a/pkg/memory/store/postgres_store_test.go
+++ b/pkg/memory/store/postgres_store_test.go
@@ -1,0 +1,16 @@
+package store
+
+import "testing"
+
+func TestTrimJSON(t *testing.T) {
+	cases := map[string]string{
+		"[1,2,3]":     "1,2,3",
+		"[[nested]]":  "nested",
+		"no brackets": "no brackets",
+	}
+	for input, want := range cases {
+		if got := trimJSON(input); got != want {
+			t.Fatalf("trimJSON(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/pkg/memory/store/vector_store.go
+++ b/pkg/memory/store/vector_store.go
@@ -1,17 +1,19 @@
-package memory
+package store
 
 import (
 	"context"
 	"time"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/memory/model"
 )
 
 // VectorStore defines the contract for long-term memory backends.
 type VectorStore interface {
 	StoreMemory(ctx context.Context, sessionID, content string, metadata map[string]any, embedding []float32) error
-	SearchMemory(ctx context.Context, queryEmbedding []float32, limit int) ([]MemoryRecord, error)
+	SearchMemory(ctx context.Context, queryEmbedding []float32, limit int) ([]model.MemoryRecord, error)
 	UpdateEmbedding(ctx context.Context, id int64, embedding []float32, lastEmbedded time.Time) error
 	DeleteMemory(ctx context.Context, ids []int64) error
-	Iterate(ctx context.Context, fn func(MemoryRecord) bool) error
+	Iterate(ctx context.Context, fn func(model.MemoryRecord) bool) error
 	Count(ctx context.Context) (int, error)
 }
 
@@ -22,6 +24,6 @@ type SchemaInitializer interface {
 
 // GraphStore is implemented by vector stores that maintain graph neighborhoods for memories.
 type GraphStore interface {
-	UpsertGraph(ctx context.Context, record MemoryRecord, edges []GraphEdge) error
-	Neighborhood(ctx context.Context, seedIDs []int64, hops, limit int) ([]MemoryRecord, error)
+	UpsertGraph(ctx context.Context, record model.MemoryRecord, edges []model.GraphEdge) error
+	Neighborhood(ctx context.Context, seedIDs []int64, hops, limit int) ([]model.MemoryRecord, error)
 }


### PR DESCRIPTION
## Summary
- split the monolithic memory package into embed, engine, model, session, and store subpackages while keeping a re-exporting facade for the public API
- update engine, session, and store implementations to share model types, graph helpers, and cosine similarity utilities across the new subpackages
- adjust tests and add focused coverage for the refactored structure, including a new Postgres store helper test

## Testing
- go test ./...
