### PR TITLE
test: add coverage across pkg modules

### DIFF
--- a/pkg/memory/embed/embed_test.go
+++ b/pkg/memory/embed/embed_test.go
@@ -1,0 +1,78 @@
+package embed
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type stubEmbedder struct {
+	vec []float32
+	err error
+}
+
+func (s stubEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	if s.vec != nil {
+		return s.vec, nil
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return []float32{float32(len(text))}, nil
+}
+
+func TestDummyEmbeddingLength(t *testing.T) {
+	vec := DummyEmbedding("hello world")
+	if len(vec) != 768 {
+		t.Fatalf("expected dummy embedding to be length 768, got %d", len(vec))
+	}
+	if vec[0] == 0 {
+		t.Fatalf("expected dummy embedding to have non-zero signal")
+	}
+}
+
+func TestSafeEmbedFallbacks(t *testing.T) {
+	dummy := DummyEmbedding("fallback")
+	got := safeEmbed(nil, "fallback")
+	if len(got) != len(dummy) {
+		t.Fatalf("expected fallback embedding length %d, got %d", len(dummy), len(got))
+	}
+
+	failing := stubEmbedder{err: errors.New("boom")}
+	got = safeEmbed(failing, "fallback")
+	if len(got) != len(dummy) {
+		t.Fatalf("expected fallback embedding length %d, got %d", len(dummy), len(got))
+	}
+}
+
+func TestSafeEmbedUsesProvidedVector(t *testing.T) {
+	expected := []float32{1, 2, 3}
+	got := safeEmbed(stubEmbedder{vec: expected}, "irrelevant")
+	if len(got) != len(expected) {
+		t.Fatalf("expected %d values, got %d", len(expected), len(got))
+	}
+}
+
+func TestAutoEmbedderSelection(t *testing.T) {
+	t.Setenv("ADK_EMBED_PROVIDER", "openai")
+	t.Setenv("ADK_EMBED_MODEL", "test-model")
+	t.Setenv("OPENAI_API_KEY", "dummy-key")
+
+	embedder := AutoEmbedder()
+	if _, ok := embedder.(*OpenAIEmbedder); !ok {
+		t.Fatalf("expected AutoEmbedder to return *OpenAIEmbedder, got %T", embedder)
+	}
+}
+
+func TestAutoEmbedderFallback(t *testing.T) {
+	t.Setenv("ADK_EMBED_PROVIDER", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("OLLAMA_HOST", "")
+	embedder := AutoEmbedder()
+	if _, ok := embedder.(DummyEmbedder); !ok {
+		t.Fatalf("expected AutoEmbedder to fall back to DummyEmbedder, got %T", embedder)
+	}
+}

--- a/pkg/memory/model/model_test.go
+++ b/pkg/memory/model/model_test.go
@@ -1,0 +1,225 @@
+package model
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestNormalizeMetadata(t *testing.T) {
+	fallback := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
+	meta := map[string]any{
+		"importance": json.Number("0.75"),
+		"source":     42,
+		"summary":    map[string]string{"text": "hello"},
+		"graph_edges": []any{
+			map[string]any{"target": json.Number("12"), "type": string(EdgeExplains)},
+			map[string]any{"target": 0, "type": "unknown"},
+		},
+	}
+	importance, source, summary, lastEmbedded, jsonStr := NormalizeMetadata(meta, fallback)
+	if math.Abs(importance-0.75) > 1e-9 {
+		t.Fatalf("unexpected importance: %v", importance)
+	}
+	if source != "42" {
+		t.Fatalf("unexpected source: %q", source)
+	}
+	if summary != "{\"text\":\"hello\"}" {
+		t.Fatalf("unexpected summary: %q", summary)
+	}
+	if lastEmbedded.IsZero() {
+		t.Fatal("expected lastEmbedded to be set")
+	}
+	decoded := DecodeMetadata(jsonStr)
+	if len(decoded) == 0 || decoded["importance"].(float64) != importance {
+		t.Fatalf("metadata not serialized correctly: %v", jsonStr)
+	}
+	edges := ValidGraphEdges(decoded)
+	if len(edges) != 1 || edges[0].Target != 12 || edges[0].Type != EdgeExplains {
+		t.Fatalf("unexpected sanitized edges: %#v", edges)
+	}
+}
+
+func TestCloneMetadataReturnsCopy(t *testing.T) {
+	original := map[string]any{"foo": "bar"}
+	cloned := CloneMetadata(original)
+	if &original == &cloned {
+		t.Fatal("expected new map instance")
+	}
+	cloned["foo"] = "baz"
+	if original["foo"].(string) != "bar" {
+		t.Fatal("expected original to remain unchanged")
+	}
+}
+
+func TestFloatFromAny(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want float64
+	}{
+		{"float64", 1.5, 1.5},
+		{"int", 2, 2},
+		{"json", json.Number("3.25"), 3.25},
+		{"string", "4.5", 4.5},
+		{"invalid", struct{}{}, 0},
+	}
+	for _, tc := range cases {
+		if got := FloatFromAny(tc.in); math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.want, got)
+		}
+	}
+}
+
+func TestStringFromAny(t *testing.T) {
+	if got := StringFromAny(nil); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+	if got := StringFromAny("hello"); got != "hello" {
+		t.Fatalf("expected \"hello\", got %q", got)
+	}
+	got := StringFromAny(map[string]int{"answer": 42})
+	if got != "{\"answer\":42}" {
+		t.Fatalf("unexpected serialization: %q", got)
+	}
+}
+
+func TestTimeFromAny(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	if got := TimeFromAny(now); !got.Equal(now) {
+		t.Fatalf("expected exact time, got %v", got)
+	}
+	if got := TimeFromAny(now.Format(time.RFC3339Nano)); !got.Equal(now) {
+		t.Fatalf("expected parsed time, got %v", got)
+	}
+	if got := TimeFromAny("invalid"); !got.IsZero() {
+		t.Fatalf("expected zero time, got %v", got)
+	}
+}
+
+func TestDecodeMetadata(t *testing.T) {
+	if meta := DecodeMetadata(""); len(meta) != 0 {
+		t.Fatalf("expected empty map, got %v", meta)
+	}
+	if meta := DecodeMetadata("not json"); len(meta) != 0 {
+		t.Fatalf("expected empty map for invalid json, got %v", meta)
+	}
+	meta := DecodeMetadata("{\"foo\":\"bar\"}")
+	if meta["foo"] != "bar" {
+		t.Fatalf("unexpected metadata: %v", meta)
+	}
+}
+
+func TestHydrateRecordFromMetadata(t *testing.T) {
+	ts := time.Now().UTC()
+	rec := &MemoryRecord{}
+	meta := map[string]any{
+		"importance":    0.8,
+		"source":        "memory",
+		"summary":       "short",
+		"last_embedded": ts.Format(time.RFC3339Nano),
+		"space":         "team",
+		"graph_edges": []any{
+			map[string]any{"target": 10, "type": string(EdgeFollows)},
+		},
+	}
+	HydrateRecordFromMetadata(rec, meta)
+	if rec.Importance != 0.8 || rec.Source != "memory" || rec.Summary != "short" || rec.Space != "team" {
+		t.Fatalf("unexpected record hydration: %#v", rec)
+	}
+	if rec.LastEmbedded.IsZero() {
+		t.Fatal("expected last embedded time to be populated")
+	}
+	if len(rec.GraphEdges) != 1 || rec.GraphEdges[0].Target != 10 {
+		t.Fatalf("expected graph edges to be hydrated, got %#v", rec.GraphEdges)
+	}
+}
+
+func TestGraphEdgeValidationAndSanitize(t *testing.T) {
+	edge := GraphEdge{Target: 5, Type: EdgeContradicts}
+	if err := edge.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bad := GraphEdge{}
+	if err := bad.Validate(); err == nil {
+		t.Fatal("expected validation error for zero target")
+	}
+
+	meta := map[string]any{
+		"graph_edges": []any{
+			map[string]any{"target": 5, "type": string(EdgeDerivedFrom)},
+			map[string]any{"target": 0, "type": "unknown"},
+		},
+	}
+	edges := SanitizeGraphEdges(meta)
+	if len(edges) != 1 || edges[0].Type != EdgeDerivedFrom {
+		t.Fatalf("unexpected sanitized edges: %#v", edges)
+	}
+	if _, ok := meta["graph_edges"].([]GraphEdge); !ok {
+		t.Fatalf("expected metadata to contain normalized edges, got %#v", meta["graph_edges"])
+	}
+}
+
+func TestDecodeGraphEdgesVariants(t *testing.T) {
+	edge := GraphEdge{Target: 7, Type: EdgeFollows}
+	cases := []any{
+		[]GraphEdge{edge},
+		[]any{map[string]any{"target": 7, "type": string(EdgeFollows)}},
+		map[string]any{"target": 7, "type": string(EdgeFollows)},
+	}
+	for _, in := range cases {
+		out := DecodeGraphEdges(in)
+		if len(out) != 1 || out[0] != edge {
+			t.Fatalf("failed to decode edges from %T", in)
+		}
+	}
+}
+
+func TestNumericToInt(t *testing.T) {
+	cases := []struct {
+		in   any
+		want int64
+	}{
+		{float64(3), 3},
+		{float32(4), 4},
+		{int(5), 5},
+		{json.Number("6"), 6},
+		{"7", 7},
+		{struct{}{}, 0},
+	}
+	for _, tc := range cases {
+		if got := numericToInt(tc.in); got != tc.want {
+			t.Fatalf("expected %d, got %d", tc.want, got)
+		}
+	}
+}
+
+func TestValidGraphEdges(t *testing.T) {
+	meta := map[string]any{
+		"graph_edges": []any{
+			[]any{8, string(EdgeFollows)},
+			[]any{0, "bad"},
+		},
+	}
+	edges := ValidGraphEdges(meta)
+	if len(edges) != 1 || edges[0].Target != 8 {
+		t.Fatalf("expected a single valid edge, got %#v", edges)
+	}
+}
+
+func TestCosineSimilarity(t *testing.T) {
+	if sim := CosineSimilarity(nil, nil); sim != 0 {
+		t.Fatalf("expected zero similarity for empty vectors, got %v", sim)
+	}
+	a := []float32{1, 0}
+	b := []float32{1, 0}
+	if sim := CosineSimilarity(a, b); math.Abs(sim-1) > 1e-9 {
+		t.Fatalf("expected similarity of 1, got %v", sim)
+	}
+	c := []float32{1, 0}
+	d := []float32{0, 1}
+	if sim := CosineSimilarity(c, d); math.Abs(sim) > 1e-9 {
+		t.Fatalf("expected orthogonal vectors to have zero similarity, got %v", sim)
+	}
+}

--- a/pkg/memory/session/memory_bank_test.go
+++ b/pkg/memory/session/memory_bank_test.go
@@ -1,0 +1,208 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/memory/embed"
+	"github.com/Raezil/go-agent-development-kit/pkg/memory/model"
+	"github.com/Raezil/go-agent-development-kit/pkg/memory/store"
+)
+
+type stubVectorStore struct {
+	mu           sync.Mutex
+	stored       []storedMemory
+	searchResp   []model.MemoryRecord
+	storeErr     error
+	searchErr    error
+	createSchema []string
+	closed       bool
+}
+
+type storedMemory struct {
+	sessionID string
+	content   string
+	metadata  map[string]any
+	embedding []float32
+}
+
+func (s *stubVectorStore) StoreMemory(_ context.Context, sessionID, content string, metadata map[string]any, embedding []float32) error {
+	if s.storeErr != nil {
+		return s.storeErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make(map[string]any, len(metadata))
+	for k, v := range metadata {
+		cp[k] = v
+	}
+	s.stored = append(s.stored, storedMemory{
+		sessionID: sessionID,
+		content:   content,
+		metadata:  cp,
+		embedding: append([]float32(nil), embedding...),
+	})
+	return nil
+}
+
+func (s *stubVectorStore) SearchMemory(_ context.Context, _ []float32, _ int) ([]model.MemoryRecord, error) {
+	if s.searchErr != nil {
+		return nil, s.searchErr
+	}
+	return s.searchResp, nil
+}
+
+func (s *stubVectorStore) UpdateEmbedding(context.Context, int64, []float32, time.Time) error {
+	return nil
+}
+func (s *stubVectorStore) DeleteMemory(context.Context, []int64) error                  { return nil }
+func (s *stubVectorStore) Iterate(context.Context, func(model.MemoryRecord) bool) error { return nil }
+func (s *stubVectorStore) Count(context.Context) (int, error)                           { return 0, nil }
+
+func (s *stubVectorStore) CreateSchema(_ context.Context, schemaPath string) error {
+	s.createSchema = append(s.createSchema, schemaPath)
+	return nil
+}
+
+func (s *stubVectorStore) Close() error {
+	s.closed = true
+	return nil
+}
+
+var _ store.VectorStore = (*stubVectorStore)(nil)
+var _ store.SchemaInitializer = (*stubVectorStore)(nil)
+
+func TestMemoryBankStoreMemoryAddsSpace(t *testing.T) {
+	svs := &stubVectorStore{}
+	bank := NewMemoryBankWithStore(svs)
+	err := bank.StoreMemory(context.Background(), "session-1", "content", "", []float32{1, 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(svs.stored) != 1 {
+		t.Fatalf("expected one stored record, got %d", len(svs.stored))
+	}
+	stored := svs.stored[0]
+	if stored.metadata["space"] != "session-1" {
+		t.Fatalf("expected space metadata to default to session, got %v", stored.metadata["space"])
+	}
+}
+
+func TestMemoryBankStoreMemoryRespectsProvidedSpace(t *testing.T) {
+	svs := &stubVectorStore{}
+	bank := NewMemoryBankWithStore(svs)
+	meta := map[string]any{"space": "shared"}
+	metaBytes, _ := json.Marshal(meta)
+	err := bank.StoreMemory(context.Background(), "session-1", "content", string(metaBytes), []float32{1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svs.stored[0].metadata["space"] != "shared" {
+		t.Fatalf("expected provided space to be preserved, got %v", svs.stored[0].metadata["space"])
+	}
+}
+
+func TestMemoryBankSearchMemoryNilStore(t *testing.T) {
+	var bank *MemoryBank
+	if results, err := bank.SearchMemory(context.Background(), nil, 5); err != nil || results != nil {
+		t.Fatalf("expected nil results and no error, got %v, %v", results, err)
+	}
+	bank = &MemoryBank{}
+	if results, err := bank.SearchMemory(context.Background(), nil, 5); err != nil || results != nil {
+		t.Fatalf("expected nil results and no error, got %v, %v", results, err)
+	}
+}
+
+func TestMemoryBankCreateSchemaAndClose(t *testing.T) {
+	svs := &stubVectorStore{}
+	bank := NewMemoryBankWithStore(svs)
+	if err := bank.CreateSchema(context.Background(), "schema.sql"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(svs.createSchema) != 1 || svs.createSchema[0] != "schema.sql" {
+		t.Fatalf("expected schema initializer to be called, got %v", svs.createSchema)
+	}
+	if err := bank.Close(); err != nil {
+		t.Fatalf("unexpected error closing bank: %v", err)
+	}
+	if !svs.closed {
+		t.Fatal("expected Close to be forwarded to store")
+	}
+}
+
+type stubEmbedder struct {
+	vec []float32
+	err error
+}
+
+func (s stubEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.vec != nil {
+		return s.vec, nil
+	}
+	return []float32{float32(len(text))}, nil
+}
+
+func TestSessionMemoryAddAndFlush(t *testing.T) {
+	svs := &stubVectorStore{}
+	bank := NewMemoryBankWithStore(svs)
+	sm := NewSessionMemory(bank, 2)
+	sm.WithEmbedder(stubEmbedder{vec: []float32{1}})
+
+	sm.AddShortTerm("s1", "first", "{}", []float32{1})
+	sm.AddShortTerm("s1", "second", "{}", []float32{2})
+	sm.AddShortTerm("s1", "third", "{}", []float32{3})
+	if len(sm.shortTerm["s1"]) != 2 {
+		t.Fatalf("expected short-term buffer to respect size, got %d", len(sm.shortTerm["s1"]))
+	}
+	if err := sm.FlushToLongTerm(context.Background(), "s1"); err != nil {
+		t.Fatalf("unexpected flush error: %v", err)
+	}
+	if len(sm.shortTerm["s1"]) != 0 {
+		t.Fatal("expected short-term cache to be cleared after flush")
+	}
+	if len(svs.stored) != 2 {
+		t.Fatalf("expected two records to be stored, got %d", len(svs.stored))
+	}
+}
+
+func TestSessionMemoryEmbedFallback(t *testing.T) {
+	sm := NewSessionMemory(&MemoryBank{}, 1)
+	sm.Embedder = stubEmbedder{err: assertErr{}}
+	vec, err := sm.Embed(context.Background(), "text")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	dummy := embed.DummyEmbedding("text")
+	if len(vec) != len(dummy) {
+		t.Fatalf("expected dummy embedding length %d, got %d", len(dummy), len(vec))
+	}
+}
+
+type assertErr struct{}
+
+func (assertErr) Error() string { return "assert" }
+
+func TestSessionMemoryRetrieveContextCombinesSources(t *testing.T) {
+	svs := &stubVectorStore{searchResp: []model.MemoryRecord{{Content: "long"}}}
+	bank := NewMemoryBankWithStore(svs)
+	sm := NewSessionMemory(bank, 2)
+	sm.WithEmbedder(stubEmbedder{vec: []float32{1}})
+
+	sm.AddShortTerm("s1", "short", "{}", []float32{1})
+	records, err := sm.RetrieveContext(context.Background(), "s1", "query", 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected two combined records, got %d", len(records))
+	}
+	if records[0].Content != "short" || records[1].Content != "long" {
+		t.Fatalf("unexpected record ordering: %#v", records)
+	}
+}

--- a/pkg/memory/session/spaces_test.go
+++ b/pkg/memory/session/spaces_test.go
@@ -1,0 +1,93 @@
+package session
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestSpaceCloneAndRole(t *testing.T) {
+	now := time.Now()
+	space := &Space{
+		Name:      "team",
+		ACL:       map[string]SpaceRole{"alice": SpaceRoleWriter},
+		ExpiresAt: now.Add(time.Hour),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	clone := space.clone()
+	if clone == space || &clone.ACL == &space.ACL {
+		t.Fatal("expected deep clone of space")
+	}
+	if clone.roleFor("alice") != SpaceRoleWriter {
+		t.Fatalf("unexpected role: %v", clone.roleFor("alice"))
+	}
+	if !space.roleFor("alice").allowsWrite() {
+		t.Fatal("expected writer role to allow writes")
+	}
+	if space.roleFor("bob") != "" {
+		t.Fatal("expected unknown principal to have empty role")
+	}
+}
+
+func TestSpaceRegistryUpsertAndGrant(t *testing.T) {
+	sr := NewSpaceRegistry(time.Hour)
+	sr.clock = func() time.Time { return time.Unix(0, 0) }
+	space := sr.Upsert(" team ", 0, map[string]SpaceRole{"alice": SpaceRoleAdmin})
+	if space == nil || space.Name != "team" {
+		t.Fatalf("unexpected space: %#v", space)
+	}
+	if err := sr.Grant("team", "bob", SpaceRoleWriter, time.Minute); err != nil {
+		t.Fatalf("unexpected grant error: %v", err)
+	}
+	if !sr.CanRead("team", "bob") || !sr.CanWrite("team", "bob") {
+		t.Fatal("expected granted writer to have read/write access")
+	}
+	sr.Revoke("team", "bob")
+	if sr.CanRead("team", "bob") {
+		t.Fatal("expected revoke to remove access")
+	}
+}
+
+func TestSpaceRegistryCheckErrors(t *testing.T) {
+	sr := NewSpaceRegistry(time.Minute)
+	sr.clock = func() time.Time { return time.Unix(0, 0) }
+	if err := sr.Check("", "alice", false); err != ErrSpaceUnknown {
+		t.Fatalf("expected ErrSpaceUnknown, got %v", err)
+	}
+	sr.Upsert("team", time.Second, map[string]SpaceRole{"alice": SpaceRoleReader})
+	sr.clock = func() time.Time { return time.Unix(10, 0) }
+	if err := sr.Check("team", "alice", false); err != ErrSpaceExpired {
+		t.Fatalf("expected ErrSpaceExpired, got %v", err)
+	}
+	sr.clock = func() time.Time { return time.Unix(0, 0) }
+	sr.Upsert("team", 0, map[string]SpaceRole{"alice": SpaceRoleReader})
+	if err := sr.Check("team", "", false); err != ErrSpaceForbidden {
+		t.Fatalf("expected ErrSpaceForbidden for empty principal, got %v", err)
+	}
+	if err := sr.Check("team", "alice", true); err != ErrSpaceForbidden {
+		t.Fatalf("expected ErrSpaceForbidden for insufficient role, got %v", err)
+	}
+}
+
+func TestSpaceRegistryListAndPrune(t *testing.T) {
+	sr := NewSpaceRegistry(time.Minute)
+	now := time.Unix(0, 0)
+	sr.clock = func() time.Time { return now }
+	sr.Upsert("alpha", time.Minute, map[string]SpaceRole{"alice": SpaceRoleReader})
+	sr.Upsert("beta", 0, map[string]SpaceRole{"alice": SpaceRoleWriter})
+	sr.Upsert("gamma", time.Second, map[string]SpaceRole{"bob": SpaceRoleAdmin})
+
+	list := sr.List("alice")
+	if len(list) != 2 || list[0] != "alpha" || list[1] != "beta" {
+		t.Fatalf("unexpected list of spaces: %v", list)
+	}
+
+	sr.clock = func() time.Time { return now.Add(2 * time.Minute) }
+	removed := sr.Prune()
+	slices.Sort(removed)
+	expected := []string{"alpha", "beta", "gamma"}
+	if !slices.Equal(removed, expected) {
+		t.Fatalf("expected expired spaces %v, got %v", expected, removed)
+	}
+}


### PR DESCRIPTION
## Summary
- add embed package tests covering auto embedder selection and fallbacks
- cover metadata utilities and vector math helpers within the memory model package
- exercise session memory bank flows and collaborative space registry logic

## Testing
- go test ./...
