### PR TITLE
Introduce modular agent development kit architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Whether you are experimenting locally or embedding agents inside an existing ser
 
 ## Key Features
 - **Runtime orchestration** – `pkg/runtime` exposes a single entry point for constructing an agent runtime with configurable models, tools, memory engines, and sub-agent registries. A thread-safe session manager keeps execution deterministic.
-- **Modular Agent Development Kit** – `pkg/kit` layers a pluggable module system on top of the existing runtime, memory, model, and tool abstractions so you can compose deployments with a few declarative options.
+- **Modular Agent Development Kit** – `pkg/adk` layers a pluggable module system on top of the existing runtime, memory, model, and tool abstractions so you can compose deployments with a few declarative options.
 - **Coordinator + specialists** – `pkg/agent` contains the core coordinator logic, while `pkg/subagents` demonstrates how to plug in specialist personas (for example, a researcher) through a `ToolCatalog` and `SubAgentDirectory` abstraction.
 - **Tooling ecosystem** – Implement the `agent.Tool` interface and register implementations (echo, calculator, clock, etc.) under `pkg/tools`. Tools become available to the coordinator prompt automatically.
 - **Retrieval-augmented memory** – `pkg/memory` layers importance scoring, weighted retrieval (similarity, recency, source, importance), maximal marginal relevance, summarisation, and pruning strategies over pluggable vector stores (PostgreSQL + pgvector, Qdrant, in-memory).
@@ -128,7 +128,7 @@ Edit `cmd/quickstart/main.go` to swap models, register additional tools, or plug
 - **Memory backends** – Use the built-in in-memory default or supply a custom `runtime.WithMemoryFactory` / `runtime.WithSessionMemoryBuilder` for Postgres, Qdrant, or bespoke vector stores.
 
 ### Building with Modules
-The `pkg/kit` package introduces a lightweight module system so you can provision capabilities declaratively:
+The `pkg/adk` package introduces a lightweight module system so you can provision capabilities declaratively:
 
 ```go
 kitInstance, _ := kit.New(ctx,

--- a/cmd/quickstart/main.go
+++ b/cmd/quickstart/main.go
@@ -3,36 +3,44 @@ package main
 import (
 	"bufio"
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
 	"strings"
 
+	"github.com/Raezil/go-agent-development-kit/pkg/adk"
+	adkmodules "github.com/Raezil/go-agent-development-kit/pkg/adk/modules"
 	"github.com/Raezil/go-agent-development-kit/pkg/agent"
-	"github.com/Raezil/go-agent-development-kit/pkg/kit"
-	kitmodules "github.com/Raezil/go-agent-development-kit/pkg/kit/modules"
 	"github.com/Raezil/go-agent-development-kit/pkg/models"
 	"github.com/Raezil/go-agent-development-kit/pkg/tools"
 )
 
 func main() {
+	qdrantURL := flag.String("qdrant-url", "http://localhost:6333", "Qdrant base URL")
+	qdrantCollection := flag.String("qdrant-collection", "adk_memories", "Qdrant collection name")
+	flag.Parse()
 	ctx := context.Background()
 
-	kitInstance, err := kit.New(ctx,
-		kit.WithDefaultSystemPrompt("You orchestrate a helpful assistant team."),
-		kit.WithModules(
-			kitmodules.NewModelModule("dummy-model", func(_ context.Context) (models.Agent, error) {
-				return models.NewDummyLLM("Quickstart agent:"), nil
+	adk, err := adk.New(ctx,
+		adk.WithDefaultSystemPrompt("You orchestrate a helpful assistant team."),
+		adk.WithModules(
+			adkmodules.NewModelModule("gemini-model", func(_ context.Context) (models.Agent, error) {
+				researcherModel, err := models.NewGeminiLLM(ctx, "gemini-2.5-pro", "Research summary:")
+				if err != nil {
+					return nil, err
+				}
+				return researcherModel, nil
 			}),
-			kitmodules.InMemoryMemoryModule(8),
-			kitmodules.NewToolModule("essentials", kitmodules.StaticToolProvider([]agent.Tool{&tools.EchoTool{}}, nil)),
+			adkmodules.InQdrantMemory(100000, *qdrantURL, *qdrantCollection),
+			adkmodules.NewToolModule("essentials", adkmodules.StaticToolProvider([]agent.Tool{&tools.EchoTool{}}, nil)),
 		),
 	)
 	if err != nil {
 		log.Fatalf("failed to initialise kit: %v", err)
 	}
 
-	agentInstance, err := kitInstance.BuildAgent(ctx)
+	agent, err := adk.BuildAgent(ctx)
 	if err != nil {
 		log.Fatalf("failed to build agent: %v", err)
 	}
@@ -52,7 +60,7 @@ func main() {
 			return
 		}
 
-		response, err := agentInstance.Respond(ctx, "quickstart-session", line)
+		response, err := agent.Respond(ctx, "quickstart-session", line)
 		if err != nil {
 			fmt.Printf("error: %v\n", err)
 			continue

--- a/pkg/adk/kit.go
+++ b/pkg/adk/kit.go
@@ -1,4 +1,4 @@
-package kit
+package adk
 
 import (
 	"context"

--- a/pkg/adk/kit_test.go
+++ b/pkg/adk/kit_test.go
@@ -1,13 +1,13 @@
-package kit_test
+package adk_test
 
 import (
 	"context"
 	"strings"
 	"testing"
 
+	"github.com/Raezil/go-agent-development-kit/pkg/adk"
+	kitmodules "github.com/Raezil/go-agent-development-kit/pkg/adk/modules"
 	"github.com/Raezil/go-agent-development-kit/pkg/agent"
-	"github.com/Raezil/go-agent-development-kit/pkg/kit"
-	kitmodules "github.com/Raezil/go-agent-development-kit/pkg/kit/modules"
 	"github.com/Raezil/go-agent-development-kit/pkg/models"
 	"github.com/Raezil/go-agent-development-kit/pkg/subagents"
 	"github.com/Raezil/go-agent-development-kit/pkg/tools"
@@ -20,9 +20,9 @@ func TestKitBuildAgent(t *testing.T) {
 
 	researcherModel := models.NewDummyLLM("Researcher reply:")
 
-	kitInstance, err := kit.New(ctx,
-		kit.WithDefaultContextLimit(6),
-		kit.WithModules(
+	kitInstance, err := adk.New(ctx,
+		adk.WithDefaultContextLimit(6),
+		adk.WithModules(
 			kitmodules.NewModelModule("coordinator", kitmodules.StaticModelProvider(models.NewDummyLLM("Coordinator:"))),
 			kitmodules.InMemoryMemoryModule(4),
 			kitmodules.NewToolModule("echo", kitmodules.StaticToolProvider([]agent.Tool{&tools.EchoTool{}}, nil)),

--- a/pkg/adk/module.go
+++ b/pkg/adk/module.go
@@ -1,4 +1,4 @@
-package kit
+package adk
 
 import "context"
 

--- a/pkg/adk/modules/helpers.go
+++ b/pkg/adk/modules/helpers.go
@@ -3,8 +3,8 @@ package modules
 import (
 	"context"
 
+	kit "github.com/Raezil/go-agent-development-kit/pkg/adk"
 	"github.com/Raezil/go-agent-development-kit/pkg/agent"
-	"github.com/Raezil/go-agent-development-kit/pkg/kit"
 	"github.com/Raezil/go-agent-development-kit/pkg/memory"
 	"github.com/Raezil/go-agent-development-kit/pkg/models"
 	"github.com/Raezil/go-agent-development-kit/pkg/runtime"
@@ -31,6 +31,20 @@ func StaticMemoryProvider(mem *memory.SessionMemory) kit.MemoryProvider {
 func InMemoryMemoryModule(window int) *MemoryModule {
 	provider := func(context.Context) (*memory.SessionMemory, error) {
 		bank := memory.NewMemoryBankWithStore(memory.NewInMemoryStore())
+		size := window
+		if size <= 0 {
+			size = 8
+		}
+		mem := memory.NewSessionMemory(bank, size)
+		mem.WithEmbedder(memory.DummyEmbedder{})
+		return mem, nil
+	}
+	return NewMemoryModule("memory", provider)
+}
+
+func InQdrantMemory(window int, baseURL string, collection string) *MemoryModule {
+	provider := func(context.Context) (*memory.SessionMemory, error) {
+		bank := memory.NewMemoryBankWithStore(memory.NewQdrantStore(baseURL, collection, ""))
 		size := window
 		if size <= 0 {
 			size = 8

--- a/pkg/adk/modules/memory_module.go
+++ b/pkg/adk/modules/memory_module.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Raezil/go-agent-development-kit/pkg/kit"
+	"github.com/Raezil/go-agent-development-kit/pkg/adk"
 )
 
 // MemoryModule registers a session memory provider with the kit.
 type MemoryModule struct {
 	name     string
-	provider kit.MemoryProvider
+	provider adk.MemoryProvider
 }
 
 // NewMemoryModule creates a memory module with the supplied provider. If name
 // is empty the module is registered as "memory".
-func NewMemoryModule(name string, provider kit.MemoryProvider) *MemoryModule {
+func NewMemoryModule(name string, provider adk.MemoryProvider) *MemoryModule {
 	if name == "" {
 		name = "memory"
 	}
@@ -24,7 +24,7 @@ func NewMemoryModule(name string, provider kit.MemoryProvider) *MemoryModule {
 
 func (m *MemoryModule) Name() string { return m.name }
 
-func (m *MemoryModule) Provision(_ context.Context, kitInstance *kit.AgentDevelopmentKit) error {
+func (m *MemoryModule) Provision(_ context.Context, kitInstance *adk.AgentDevelopmentKit) error {
 	if m.provider == nil {
 		return fmt.Errorf("memory provider is nil")
 	}

--- a/pkg/adk/modules/model_module.go
+++ b/pkg/adk/modules/model_module.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Raezil/go-agent-development-kit/pkg/kit"
+	"github.com/Raezil/go-agent-development-kit/pkg/adk"
 )
 
 // ModelModule wires a model provider into the kit.
 type ModelModule struct {
 	name     string
-	provider kit.ModelProvider
+	provider adk.ModelProvider
 }
 
 // NewModelModule creates a module that registers the supplied model provider.
 // If name is empty the module will expose "model".
-func NewModelModule(name string, provider kit.ModelProvider) *ModelModule {
+func NewModelModule(name string, provider adk.ModelProvider) *ModelModule {
 	if name == "" {
 		name = "model"
 	}
@@ -24,7 +24,7 @@ func NewModelModule(name string, provider kit.ModelProvider) *ModelModule {
 
 func (m *ModelModule) Name() string { return m.name }
 
-func (m *ModelModule) Provision(_ context.Context, kitInstance *kit.AgentDevelopmentKit) error {
+func (m *ModelModule) Provision(_ context.Context, kitInstance *adk.AgentDevelopmentKit) error {
 	if m.provider == nil {
 		return fmt.Errorf("model provider is nil")
 	}

--- a/pkg/adk/modules/runtime_module.go
+++ b/pkg/adk/modules/runtime_module.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Raezil/go-agent-development-kit/pkg/kit"
+	"github.com/Raezil/go-agent-development-kit/pkg/adk"
 )
 
 // RuntimeModule registers a runtime provider with the kit.
 type RuntimeModule struct {
 	name     string
-	provider kit.RuntimeProvider
+	provider adk.RuntimeProvider
 }
 
 // NewRuntimeModule creates a runtime module with the provided factory. If name
 // is empty the module uses "runtime".
-func NewRuntimeModule(name string, provider kit.RuntimeProvider) *RuntimeModule {
+func NewRuntimeModule(name string, provider adk.RuntimeProvider) *RuntimeModule {
 	if name == "" {
 		name = "runtime"
 	}
@@ -24,7 +24,7 @@ func NewRuntimeModule(name string, provider kit.RuntimeProvider) *RuntimeModule 
 
 func (m *RuntimeModule) Name() string { return m.name }
 
-func (m *RuntimeModule) Provision(_ context.Context, kitInstance *kit.AgentDevelopmentKit) error {
+func (m *RuntimeModule) Provision(_ context.Context, kitInstance *adk.AgentDevelopmentKit) error {
 	if m.provider == nil {
 		return fmt.Errorf("runtime provider is nil")
 	}

--- a/pkg/adk/modules/subagent_module.go
+++ b/pkg/adk/modules/subagent_module.go
@@ -3,18 +3,18 @@ package modules
 import (
 	"context"
 
-	"github.com/Raezil/go-agent-development-kit/pkg/kit"
+	"github.com/Raezil/go-agent-development-kit/pkg/adk"
 )
 
 // SubAgentModule registers a sub-agent provider with the kit.
 type SubAgentModule struct {
 	name     string
-	provider kit.SubAgentProvider
+	provider adk.SubAgentProvider
 }
 
 // NewSubAgentModule creates a sub-agent module. If name is empty the module is
 // registered as "subagents".
-func NewSubAgentModule(name string, provider kit.SubAgentProvider) *SubAgentModule {
+func NewSubAgentModule(name string, provider adk.SubAgentProvider) *SubAgentModule {
 	if name == "" {
 		name = "subagents"
 	}
@@ -23,7 +23,7 @@ func NewSubAgentModule(name string, provider kit.SubAgentProvider) *SubAgentModu
 
 func (m *SubAgentModule) Name() string { return m.name }
 
-func (m *SubAgentModule) Provision(_ context.Context, kitInstance *kit.AgentDevelopmentKit) error {
+func (m *SubAgentModule) Provision(_ context.Context, kitInstance *adk.AgentDevelopmentKit) error {
 	kitInstance.UseSubAgentProvider(m.provider)
 	return nil
 }

--- a/pkg/adk/modules/tool_module.go
+++ b/pkg/adk/modules/tool_module.go
@@ -3,19 +3,19 @@ package modules
 import (
 	"context"
 
-	"github.com/Raezil/go-agent-development-kit/pkg/kit"
+	"github.com/Raezil/go-agent-development-kit/pkg/adk"
 )
 
 // ToolModule registers a tool provider with the kit.
 type ToolModule struct {
 	name     string
-	provider kit.ToolProvider
+	provider adk.ToolProvider
 }
 
 // NewToolModule constructs a tool module. If name is empty it defaults to
 // "tools". When registering multiple tool modules provide distinct names to
 // preserve ordering in diagnostics.
-func NewToolModule(name string, provider kit.ToolProvider) *ToolModule {
+func NewToolModule(name string, provider adk.ToolProvider) *ToolModule {
 	if name == "" {
 		name = "tools"
 	}
@@ -24,7 +24,7 @@ func NewToolModule(name string, provider kit.ToolProvider) *ToolModule {
 
 func (m *ToolModule) Name() string { return m.name }
 
-func (m *ToolModule) Provision(_ context.Context, kitInstance *kit.AgentDevelopmentKit) error {
+func (m *ToolModule) Provision(_ context.Context, kitInstance *adk.AgentDevelopmentKit) error {
 	kitInstance.UseToolProvider(m.provider)
 	return nil
 }

--- a/pkg/adk/options.go
+++ b/pkg/adk/options.go
@@ -1,4 +1,4 @@
-package kit
+package adk
 
 // Option configures the AgentDevelopmentKit during construction.
 type Option func(*AgentDevelopmentKit) error

--- a/pkg/adk/providers.go
+++ b/pkg/adk/providers.go
@@ -1,4 +1,4 @@
-package kit
+package adk
 
 import (
 	"context"


### PR DESCRIPTION
## Summary
- add a modular `pkg/adk` package that centralises model, memory, tool, and sub-agent provisioning through pluggable modules
- provide helper modules, static providers, and a zero-config `cmd/quickstart` example built on the new kit
- update the documentation and add coverage for building agents via the kit API

## Testing
- go test ./...
