### PR TITLE
Add static GO-ADK marketing site

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,0 +1,344 @@
+:root {
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --color-background: #090b1a;
+  --color-surface: #10142d;
+  --color-surface-light: #f5f6fb;
+  --color-surface-accent: linear-gradient(135deg, #4f46e5, #3b82f6);
+  --color-primary: #6366f1;
+  --color-primary-dark: #4f46e5;
+  --color-ghost: rgba(99, 102, 241, 0.1);
+  --color-text: #13183f;
+  --color-text-muted: rgba(19, 24, 63, 0.7);
+  --color-white: #ffffff;
+  --shadow-lg: 0 30px 60px rgba(15, 23, 42, 0.2);
+  --shadow-md: 0 15px 40px rgba(15, 23, 42, 0.18);
+  --shadow-sm: 0 8px 20px rgba(15, 23, 42, 0.12);
+  --border-radius-lg: 24px;
+  --border-radius-md: 18px;
+  --border-radius-sm: 12px;
+  --container-width: min(1120px, 92vw);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--color-white);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-primary);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: var(--container-width);
+  margin: 0 auto;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 120px 0 96px;
+  background: radial-gradient(circle at 20% -10%, rgba(99, 102, 241, 0.45), transparent 55%),
+              radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.35), transparent 60%),
+              #050816;
+  color: var(--color-white);
+}
+
+.hero__background {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 50%, rgba(99, 102, 241, 0.15), transparent 65%);
+  opacity: 0.9;
+  z-index: 0;
+}
+
+.hero__content {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  text-transform: uppercase;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  margin-bottom: 24px;
+}
+
+.hero h1 {
+  font-size: clamp(2.8rem, 5vw, 3.75rem);
+  line-height: 1.05;
+  margin: 0 0 20px;
+}
+
+.hero__subtitle {
+  font-size: 1.125rem;
+  color: rgba(255, 255, 255, 0.8);
+  margin-bottom: 36px;
+}
+
+.hero__actions {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 40px;
+}
+
+.hero__stats {
+  display: flex;
+  gap: 40px;
+  margin: 0;
+}
+
+.hero__stats dt {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.hero__stats dd {
+  margin: 4px 0 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.section {
+  padding: 96px 0;
+  background: var(--color-white);
+}
+
+.section--light {
+  background: var(--color-surface-light);
+}
+
+.section--accent {
+  background: var(--color-surface-accent);
+  color: var(--color-white);
+}
+
+.section__lede {
+  max-width: 640px;
+  font-size: 1.1rem;
+  color: var(--color-text-muted);
+}
+
+.section--light .section__lede {
+  color: rgba(19, 24, 63, 0.8);
+}
+
+.section__split {
+  display: grid;
+  gap: 48px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: center;
+}
+
+.feature-grid {
+  margin-top: 48px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.feature-card {
+  padding: 28px;
+  border-radius: var(--border-radius-md);
+  background: var(--color-white);
+  box-shadow: var(--shadow-sm);
+  border: 1px solid rgba(99, 102, 241, 0.08);
+}
+
+.feature-card h3 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-size: 1.15rem;
+}
+
+.bullet-list {
+  padding-left: 18px;
+  margin: 24px 0 0;
+  color: var(--color-text-muted);
+}
+
+.code-block {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 22px 24px;
+  border-radius: var(--border-radius-md);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+  font-size: 0.95rem;
+  overflow-x: auto;
+}
+
+.cards {
+  margin-top: 40px;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: var(--color-white);
+  border-radius: var(--border-radius-md);
+  padding: 32px;
+  box-shadow: var(--shadow-sm);
+  border: 1px solid rgba(99, 102, 241, 0.08);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.capability-grid {
+  display: grid;
+  gap: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  margin-top: 48px;
+}
+
+.capability {
+  padding: 32px;
+  border-radius: var(--border-radius-md);
+  background: var(--color-surface);
+  color: rgba(255, 255, 255, 0.92);
+  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.capability h3 {
+  margin-top: 0;
+  color: var(--color-white);
+}
+
+.capability ul {
+  padding-left: 18px;
+  margin: 16px 0 0;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.capability ul li + li {
+  margin-top: 8px;
+}
+
+.cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 14px 26px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+}
+
+.button--primary {
+  background: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: var(--shadow-md);
+}
+
+.button--primary:hover {
+  box-shadow: 0 20px 40px rgba(99, 102, 241, 0.35);
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--color-white);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.button--ghost:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.button--light {
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--color-white);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.footer {
+  background: #050816;
+  color: rgba(255, 255, 255, 0.8);
+  padding: 48px 0 32px;
+}
+
+.footer__content {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.footer__nav {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.footer__nav a {
+  color: rgba(255, 255, 255, 0.75);
+  font-weight: 500;
+}
+
+.footer__note {
+  text-align: center;
+  margin: 32px 0 0;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding: 96px 0 80px;
+  }
+
+  .hero__actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero__stats {
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .cta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Go Agent Development Kit (GO-ADK)</title>
+  <link rel="stylesheet" href="assets/style.css" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="hero">
+    <div class="container hero__content">
+      <div class="hero__badge">GO-ADK</div>
+      <h1>Build production-ready AI agents in Go.</h1>
+      <p class="hero__subtitle">
+        A batteries-included toolkit inspired by Google's Agent Development Kit. Compose language models,
+        tools, memory, and sub-agents with pragmatic APIs that keep you shipping fast.
+      </p>
+      <div class="hero__actions">
+        <a class="button button--primary" href="https://github.com/Raezil/go-agent-development-kit">View on GitHub</a>
+        <a class="button button--ghost" href="#quick-start">Quick Start</a>
+      </div>
+      <dl class="hero__stats">
+        <div>
+          <dt>Go 1.22+</dt>
+          <dd>Compatible</dd>
+        </div>
+        <div>
+          <dt>MIT</dt>
+          <dd>Open Source</dd>
+        </div>
+        <div>
+          <dt>UTCP</dt>
+          <dd>Native Tooling</dd>
+        </div>
+      </dl>
+    </div>
+    <div class="hero__background" aria-hidden="true"></div>
+  </header>
+
+  <main>
+    <section class="section section--light" id="why">
+      <div class="container">
+        <h2>Why GO-ADK?</h2>
+        <p class="section__lede">
+          Modern agents demand more than a single model call. GO-ADK orchestrates models, tools, memory, and multi-agent workflows
+          so you can focus on domain-specific logic instead of plumbing.
+        </p>
+        <div class="feature-grid">
+          <article class="feature-card">
+            <h3>Orchestrated Runtime</h3>
+            <p>
+              Configure coordinator models, tool catalogs, sub-agent registries, and memory stores using functional options. Sessions
+              are thread-safe and deterministic.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Modular Kit</h3>
+            <p>
+              Compose ready-made modules for models, memory, tools, and runtime configuration. Swap components without rewriting your application.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Tooling Ecosystem</h3>
+            <p>
+              Implement the <code>agent.Tool</code> interface once and register it everywhere. Built-in examples cover calculators, clocks, echo responders, and more.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Advanced Memory</h3>
+            <p>
+              Leverage importance scoring, recency weighting, maximal marginal relevance, and pluggable vector stores like PostgreSQL/pgvector or Qdrant.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="architecture">
+      <div class="container">
+        <div class="section__split">
+          <div>
+            <h2>Architecture Overview</h2>
+            <p>
+              The kit exposes a layered design so you can start with a simple runtime and grow into modular deployments. Each package focuses on a single responsibility,
+              empowering you to extend or replace components as your product evolves.
+            </p>
+            <ul class="bullet-list">
+              <li><strong>pkg/runtime:</strong> Session management, orchestration, UTCP tool calling.</li>
+              <li><strong>pkg/agent:</strong> Coordinator logic, tool routing, and sub-agent delegation.</li>
+              <li><strong>pkg/memory:</strong> Retrieval augmented memory with configurable heuristics.</li>
+              <li><strong>pkg/models:</strong> Gemini, Anthropic, Ollama, and dummy adapters behind a unified interface.</li>
+              <li><strong>pkg/subagents:</strong> Specialist personas wired through the ToolCatalog.</li>
+              <li><strong>pkg/tools:</strong> Built-in tools ready to register.</li>
+            </ul>
+          </div>
+          <pre class="code-block"><code>cmd/demo              # CLI entry point to drive the runtime
+cmd/quickstart        # Zero-config sample using the high-level kit
+pkg/
+├── adk               # Modular agent kit + module interfaces
+├── runtime           # High-level runtime + session management
+├── agent             # Coordinator agent, tool routing
+├── memory            # Memory engine & vector stores
+├── models            # Model adapters (Gemini, Anthropic, ...)
+├── subagents         # Specialist personas
+└── tools             # Built-in tools</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--light" id="quick-start">
+      <div class="container">
+        <h2>Quick Start</h2>
+        <div class="cards">
+          <article class="card">
+            <h3>Install</h3>
+            <pre class="code-block"><code>git clone https://github.com/Raezil/go-agent-development-kit.git
+cd go-agent-development-kit
+go mod download</code></pre>
+          </article>
+          <article class="card">
+            <h3>Configure</h3>
+            <pre class="code-block"><code>export GOOGLE_API_KEY=&quot;your-gemini-api-key&quot;
+export DATABASE_URL=&quot;postgres://admin:admin@localhost:5432/ragdb?sslmode=disable&quot;
+export ADK_EMBED_PROVIDER=&quot;gemini&quot;</code></pre>
+          </article>
+          <article class="card">
+            <h3>Run a Demo</h3>
+            <pre class="code-block"><code>go run ./cmd/demo --dsn &quot;$DATABASE_URL&quot;</code></pre>
+            <p>Or try the zero-config sample with <code>go run ./cmd/quickstart</code>.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="capabilities">
+      <div class="container">
+        <h2>Capabilities</h2>
+        <div class="capability-grid">
+          <article class="capability">
+            <h3>Memory Engine</h3>
+            <p>Weighted retrieval, clustering, summarisation, and pruning keep context relevant without sacrificing recall.</p>
+            <ul>
+              <li>Configurable similarity vs. recency weightings</li>
+              <li>Source boosting for critical signals</li>
+              <li>MMR and summarisation pipelines</li>
+            </ul>
+          </article>
+          <article class="capability">
+            <h3>Tooling &amp; Sub-Agents</h3>
+            <p>Register any number of tools and specialist personas. UTCP keeps invocation provider-agnostic.</p>
+            <ul>
+              <li>Declarative tool catalogs</li>
+              <li>Sub-agent directories</li>
+              <li>Runtime prompts for orchestration</li>
+            </ul>
+          </article>
+          <article class="capability">
+            <h3>Deployment Ready</h3>
+            <p>Integrates with PostgreSQL/pgvector, ships with deterministic dummy models, and follows Go best practices for testing.</p>
+            <ul>
+              <li>In-memory mode for local prototyping</li>
+              <li>Schema bootstrapping via runtime options</li>
+              <li>Interfaces for plugging in custom providers</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--accent" id="call-to-action">
+      <div class="container cta">
+        <div>
+          <h2>Ship smarter agents faster.</h2>
+          <p>Start with the quickstart template, customise modules, and deploy your production-ready Go agents today.</p>
+        </div>
+        <a class="button button--light" href="https://github.com/Raezil/go-agent-development-kit">Get the code</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer__content">
+      <div>
+        <strong>Go Agent Development Kit</strong>
+        <p>Inspired by Google's Agent Development Kit documentation.</p>
+      </div>
+      <nav class="footer__nav">
+        <a href="#why">Why</a>
+        <a href="#architecture">Architecture</a>
+        <a href="#quick-start">Quick Start</a>
+        <a href="#capabilities">Capabilities</a>
+      </nav>
+    </div>
+    <p class="footer__note">&copy; <span id="year"></span> GO-ADK. Built with Go and curiosity.</p>
+  </footer>
+
+  <script>
+    const yearEl = document.getElementById('year');
+    if (yearEl) {
+      yearEl.textContent = new Date().getFullYear();
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone `docs/index.html` landing page for the Go Agent Development Kit
- create shared styles that mirror the structure of the Google ADK documentation site

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68f64e56c30083228d80b29dc2569fe2