### PR TITLE
Gate fastembed provider behind build tag

### DIFF
--- a/pkg/memory/embed/embed.go
+++ b/pkg/memory/embed/embed.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"os"
 	"strings"
-
-	fastembed "github.com/anush008/fastembed-go"
 )
 
 // Embedder is a pluggable text-embedding provider.
@@ -57,12 +55,10 @@ func AutoEmbedder() Embedder {
 			return e
 		}
 	case "fastembed":
-		if e, err := NewFastEmbeed(context.Background(), &Options{
-			Model:     fastembed.BGESmallENV15,
-			CacheDir:  ".fastembed",
-			BatchSize: 64,
-		}); err == nil {
-			return e
+		if opts := defaultFastEmbedOptions(); opts != nil {
+			if e, err := NewFastEmbeed(context.Background(), opts); err == nil {
+				return e
+			}
 		}
 	}
 

--- a/pkg/memory/embed/fast_embed_fast.go
+++ b/pkg/memory/embed/fast_embed_fast.go
@@ -1,3 +1,5 @@
+//go:build fastembed
+
 package embed
 
 import (
@@ -8,25 +10,26 @@ import (
 	fastembed "github.com/anush008/fastembed-go"
 )
 
-type Options struct {
-	Model     fastembed.EmbeddingModel // e.g. fastembed.BGESmallENV15 (default)
-	CacheDir  string                   // e.g. ".fastembed"
-	MaxLength int                      // token limit, 0 = default
-	BatchSize int                      // defaults to 256 in library; we’ll cap by CPUs below
-}
-
 type FastEmbedder struct {
 	m   *fastembed.FlagEmbedding
 	dim int
 	bs  int
 }
 
+func defaultFastEmbedOptions() *Options {
+	return &Options{
+		Model:     string(fastembed.BGESmallENV15),
+		CacheDir:  ".fastembed",
+		BatchSize: 64,
+	}
+}
+
 func NewFastEmbeed(ctx context.Context, opt *Options) (Embedder, error) {
 	var init *fastembed.InitOptions
 	if opt != nil {
 		init = &fastembed.InitOptions{
-			Model:     opt.Model,    // zero value picks default (bge-small-en-v1.5)
-			CacheDir:  opt.CacheDir, // optional
+			Model:     fastembed.EmbeddingModel(opt.Model),
+			CacheDir:  opt.CacheDir,
 			MaxLength: opt.MaxLength,
 		}
 	}
@@ -34,7 +37,6 @@ func NewFastEmbeed(ctx context.Context, opt *Options) (Embedder, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Batch heuristic: keep it modest for desktop CPUs
 	bs := 64
 	if opt != nil && opt.BatchSize > 0 {
 		bs = opt.BatchSize
@@ -42,7 +44,7 @@ func NewFastEmbeed(ctx context.Context, opt *Options) (Embedder, error) {
 	if bs > 4*runtime.GOMAXPROCS(0) {
 		bs = 4 * runtime.GOMAXPROCS(0)
 	}
-	return &FastEmbedder{m: m, dim: 768, bs: bs}, nil // bge-small-en-v1.5 = 768 dims
+	return &FastEmbedder{m: m, dim: 768, bs: bs}, nil
 }
 
 func (e *FastEmbedder) Close() error {
@@ -54,7 +56,6 @@ func (e *FastEmbedder) Close() error {
 
 func (e *FastEmbedder) Dim() int { return e.dim }
 
-// EmbedPassages embeds a batch of “documents/passages” (adds prefix if missing).
 func (e *FastEmbedder) EmbedPassages(ctx context.Context, docs []string) ([][]float32, error) {
 	inputs := make([]string, len(docs))
 	for i, d := range docs {
@@ -71,7 +72,6 @@ func (e *FastEmbedder) EmbedPassages(ctx context.Context, docs []string) ([][]fl
 	return out, nil
 }
 
-// EmbedQuery embeds a single query string.
 func (e *FastEmbedder) Embed(ctx context.Context, q string) ([]float32, error) {
 	return e.m.QueryEmbed(q)
 }

--- a/pkg/memory/embed/fast_embed_opts.go
+++ b/pkg/memory/embed/fast_embed_opts.go
@@ -1,0 +1,8 @@
+package embed
+
+type Options struct {
+	Model     string
+	CacheDir  string
+	MaxLength int
+	BatchSize int
+}

--- a/pkg/memory/embed/fast_embed_stub.go
+++ b/pkg/memory/embed/fast_embed_stub.go
@@ -1,0 +1,28 @@
+//go:build !fastembed
+
+package embed
+
+import (
+	"context"
+	"fmt"
+)
+
+type FastEmbedder struct{}
+
+func defaultFastEmbedOptions() *Options { return nil }
+
+func NewFastEmbeed(ctx context.Context, opt *Options) (Embedder, error) {
+	return nil, fmt.Errorf("fastembed support not included; rebuild with -tags fastembed")
+}
+
+func (FastEmbedder) Close() error { return nil }
+
+func (FastEmbedder) Dim() int { return 0 }
+
+func (FastEmbedder) EmbedPassages(ctx context.Context, docs []string) ([][]float32, error) {
+	return nil, fmt.Errorf("fastembed support not included")
+}
+
+func (FastEmbedder) Embed(ctx context.Context, q string) ([]float32, error) {
+	return nil, fmt.Errorf("fastembed support not included")
+}


### PR DESCRIPTION
## Summary
- split the fastembed implementation behind a `fastembed` build tag with a stub when it is disabled
- remove the unconditional fastembed import and lazily construct default options for the provider
