### PR TITLE
feat(memory): add multi-vector retrieval support

### DIFF
--- a/pkg/memory/embed/embed.go
+++ b/pkg/memory/embed/embed.go
@@ -13,11 +13,22 @@ type Embedder interface {
 	Embed(ctx context.Context, text string) ([]float32, error)
 }
 
+// MultiVectorEmbedder returns multiple embeddings representing different aspects of the text.
+type MultiVectorEmbedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+	EmbedMany(ctx context.Context, text string) ([][]float32, error)
+}
+
 // ---------- Dummy (fallback) ----------
 type DummyEmbedder struct{}
 
 func (DummyEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
 	return DummyEmbedding(text), nil
+}
+
+func (DummyEmbedder) EmbedMany(ctx context.Context, text string) ([][]float32, error) {
+	vec, _ := DummyEmbedder{}.Embed(ctx, text)
+	return [][]float32{vec}, nil
 }
 
 // DummyEmbedding is kept for tests/back-compat.

--- a/pkg/memory/model/record.go
+++ b/pkg/memory/model/record.go
@@ -4,18 +4,42 @@ import "time"
 
 // MemoryRecord represents a persisted memory entry in the vector store.
 type MemoryRecord struct {
-	ID            int64       `json:"id"`
-	SessionID     string      `json:"session_id"`
-	Space         string      `json:"space"`
-	Content       string      `json:"content"`
-	Metadata      string      `json:"metadata"`
-	Embedding     []float32   `json:"embedding"`
-	Score         float64     `json:"score"`
-	Importance    float64     `json:"importance"`
-	Source        string      `json:"source"`
-	Summary       string      `json:"summary"`
-	CreatedAt     time.Time   `json:"created_at"`
-	LastEmbedded  time.Time   `json:"last_embedded"`
-	WeightedScore float64     `json:"weighted_score"`
-	GraphEdges    []GraphEdge `json:"graph_edges"`
+	ID              int64       `json:"id"`
+	SessionID       string      `json:"session_id"`
+	Space           string      `json:"space"`
+	Content         string      `json:"content"`
+	Metadata        string      `json:"metadata"`
+	Embedding       []float32   `json:"embedding"`
+	MultiEmbeddings [][]float32 `json:"multi_embeddings,omitempty"`
+	Score           float64     `json:"score"`
+	Importance      float64     `json:"importance"`
+	Source          string      `json:"source"`
+	Summary         string      `json:"summary"`
+	CreatedAt       time.Time   `json:"created_at"`
+	LastEmbedded    time.Time   `json:"last_embedded"`
+	WeightedScore   float64     `json:"weighted_score"`
+	GraphEdges      []GraphEdge `json:"graph_edges"`
+}
+
+// AllEmbeddings returns the primary embedding and any additional vectors associated with the record.
+func (r MemoryRecord) AllEmbeddings() [][]float32 {
+	total := 0
+	if len(r.Embedding) > 0 {
+		total++
+	}
+	total += len(r.MultiEmbeddings)
+	if total == 0 {
+		return nil
+	}
+	vectors := make([][]float32, 0, total)
+	if len(r.Embedding) > 0 {
+		vectors = append(vectors, r.Embedding)
+	}
+	for _, extra := range r.MultiEmbeddings {
+		if len(extra) == 0 {
+			continue
+		}
+		vectors = append(vectors, extra)
+	}
+	return vectors
 }

--- a/pkg/memory/model/similarity.go
+++ b/pkg/memory/model/similarity.go
@@ -22,3 +22,28 @@ func CosineSimilarity(a, b []float32) float64 {
 	}
 	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
 }
+
+// MaxCosineSimilarity computes the maximum cosine similarity across all vector pairs.
+func MaxCosineSimilarity(a [][]float32, b [][]float32) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	best := math.Inf(-1)
+	for _, av := range a {
+		if len(av) == 0 {
+			continue
+		}
+		for _, bv := range b {
+			if len(bv) == 0 {
+				continue
+			}
+			if sim := CosineSimilarity(av, bv); sim > best {
+				best = sim
+			}
+		}
+	}
+	if best == math.Inf(-1) {
+		return 0
+	}
+	return best
+}

--- a/pkg/memory/store/postgres_store.go
+++ b/pkg/memory/store/postgres_store.go
@@ -53,17 +53,18 @@ func (ps *PostgresStore) StoreMemory(ctx context.Context, sessionID, content str
 	}
 	meta := model.DecodeMetadata(metadataJSON)
 	rec := model.MemoryRecord{
-		ID:           id,
-		SessionID:    sessionID,
-		Space:        model.StringFromAny(meta["space"]),
-		Content:      content,
-		Metadata:     metadataJSON,
-		Embedding:    embedding,
-		Importance:   importance,
-		Source:       source,
-		Summary:      summary,
-		LastEmbedded: lastEmbedded,
-		GraphEdges:   model.ValidGraphEdges(meta),
+		ID:              id,
+		SessionID:       sessionID,
+		Space:           model.StringFromAny(meta["space"]),
+		Content:         content,
+		Metadata:        metadataJSON,
+		Embedding:       embedding,
+		MultiEmbeddings: model.Float32MatrixFromAny(meta["multi_embeddings"]),
+		Importance:      importance,
+		Source:          source,
+		Summary:         summary,
+		LastEmbedded:    lastEmbedded,
+		GraphEdges:      model.ValidGraphEdges(meta),
 	}
 	if rec.Space == "" {
 		rec.Space = sessionID

--- a/pkg/memory/store/qdrant_store.go
+++ b/pkg/memory/store/qdrant_store.go
@@ -310,17 +310,18 @@ func (qs *QdrantStore) SearchMemory(ctx context.Context, queryEmbedding []float3
 			metaMap = model.DecodeMetadata(encodeMetadata(meta["metadata"]))
 		}
 		record := model.MemoryRecord{
-			ID:           id,
-			SessionID:    model.StringFromAny(meta["session_id"]),
-			Content:      model.StringFromAny(meta["content"]),
-			Metadata:     encodeMetadata(meta["metadata"]),
-			Embedding:    point.Vector,
-			Score:        point.Score,
-			Importance:   model.FloatFromAny(meta["importance"]),
-			Source:       model.StringFromAny(meta["source"]),
-			Summary:      model.StringFromAny(meta["summary"]),
-			CreatedAt:    model.TimeFromAny(meta["created_at"]),
-			LastEmbedded: model.TimeFromAny(meta["last_embedded"]),
+			ID:              id,
+			SessionID:       model.StringFromAny(meta["session_id"]),
+			Content:         model.StringFromAny(meta["content"]),
+			Metadata:        encodeMetadata(meta["metadata"]),
+			Embedding:       point.Vector,
+			MultiEmbeddings: model.Float32MatrixFromAny(metaMap["multi_embeddings"]),
+			Score:           point.Score,
+			Importance:      model.FloatFromAny(meta["importance"]),
+			Source:          model.StringFromAny(meta["source"]),
+			Summary:         model.StringFromAny(meta["summary"]),
+			CreatedAt:       model.TimeFromAny(meta["created_at"]),
+			LastEmbedded:    model.TimeFromAny(meta["last_embedded"]),
 		}
 		model.HydrateRecordFromMetadata(&record, metaMap)
 		if record.Space == "" {
@@ -424,7 +425,9 @@ func (qs *QdrantStore) Iterate(ctx context.Context, fn func(model.MemoryRecord) 
 				CreatedAt:    model.TimeFromAny(meta["created_at"]),
 				LastEmbedded: model.TimeFromAny(meta["last_embedded"]),
 			}
-			model.HydrateRecordFromMetadata(&rec, model.DecodeMetadata(rec.Metadata))
+			metaDecoded := model.DecodeMetadata(rec.Metadata)
+			rec.MultiEmbeddings = model.Float32MatrixFromAny(metaDecoded["multi_embeddings"])
+			model.HydrateRecordFromMetadata(&rec, metaDecoded)
 
 			if cont := fn(rec); !cont {
 				return nil
@@ -589,16 +592,17 @@ func (qs *QdrantStore) Neighborhood(ctx context.Context, seedIDs []int64, hops, 
 			metaMap = model.DecodeMetadata(encodeMetadata(meta["metadata"]))
 		}
 		record := model.MemoryRecord{
-			ID:           id,
-			SessionID:    model.StringFromAny(meta["session_id"]),
-			Content:      model.StringFromAny(meta["content"]),
-			Metadata:     encodeMetadata(meta["metadata"]),
-			Embedding:    point.Vector,
-			Importance:   model.FloatFromAny(meta["importance"]),
-			Source:       model.StringFromAny(meta["source"]),
-			Summary:      model.StringFromAny(meta["summary"]),
-			CreatedAt:    model.TimeFromAny(meta["created_at"]),
-			LastEmbedded: model.TimeFromAny(meta["last_embedded"]),
+			ID:              id,
+			SessionID:       model.StringFromAny(meta["session_id"]),
+			Content:         model.StringFromAny(meta["content"]),
+			Metadata:        encodeMetadata(meta["metadata"]),
+			Embedding:       point.Vector,
+			MultiEmbeddings: model.Float32MatrixFromAny(metaMap["multi_embeddings"]),
+			Importance:      model.FloatFromAny(meta["importance"]),
+			Source:          model.StringFromAny(meta["source"]),
+			Summary:         model.StringFromAny(meta["summary"]),
+			CreatedAt:       model.TimeFromAny(meta["created_at"]),
+			LastEmbedded:    model.TimeFromAny(meta["last_embedded"]),
 		}
 		model.HydrateRecordFromMetadata(&record, metaMap)
 		if record.Space == "" {

--- a/pkg/memory/store/vector_store.go
+++ b/pkg/memory/store/vector_store.go
@@ -17,6 +17,12 @@ type VectorStore interface {
 	Count(ctx context.Context) (int, error)
 }
 
+// MultiVectorStore can persist and retrieve memories with multiple embeddings.
+type MultiVectorStore interface {
+	StoreMemoryMulti(ctx context.Context, sessionID, content string, metadata map[string]any, embeddings [][]float32) error
+	SearchMemoryMulti(ctx context.Context, queryEmbeddings [][]float32, limit int) ([]model.MemoryRecord, error)
+}
+
 // SchemaInitializer allows stores to expose optional schema/bootstrap routines.
 type SchemaInitializer interface {
 	CreateSchema(ctx context.Context, schemaPath string) error


### PR DESCRIPTION
## Summary
- add a multi-vector embedder interface and engine support for combining primary and additional embeddings during storage and retrieval
- extend memory stores to persist extra embeddings, expose a multi-vector store contract, and hydrate records with auxiliary vectors
- cover the new retrieval path with unit tests using a custom multi-vector embedder
