### PR TITLE
Ensure stores populate embeddings from multi-vector metadata

### DIFF
--- a/pkg/memory/store/in_memory_store.go
+++ b/pkg/memory/store/in_memory_store.go
@@ -34,6 +34,17 @@ func (s *InMemoryStore) StoreMemory(_ context.Context, sessionID, content string
 	if space == "" {
 		space = sessionID
 	}
+	matrix := model.ValidEmbeddingMatrix(meta)
+	storedEmbedding := append([]float32(nil), embedding...)
+	if len(storedEmbedding) == 0 {
+		for _, vec := range matrix {
+			if len(vec) == 0 {
+				continue
+			}
+			storedEmbedding = append([]float32(nil), vec...)
+			break
+		}
+	}
 	s.nextID++
 	record := model.MemoryRecord{
 		ID:              s.nextID,
@@ -41,14 +52,14 @@ func (s *InMemoryStore) StoreMemory(_ context.Context, sessionID, content string
 		Space:           space,
 		Content:         content,
 		Metadata:        metadataJSON,
-		Embedding:       append([]float32(nil), embedding...),
+		Embedding:       storedEmbedding,
 		Importance:      importance,
 		Source:          source,
 		Summary:         summary,
 		CreatedAt:       now,
 		LastEmbedded:    lastEmbedded,
 		GraphEdges:      model.ValidGraphEdges(meta),
-		EmbeddingMatrix: model.ValidEmbeddingMatrix(meta),
+		EmbeddingMatrix: matrix,
 	}
 	s.records[record.ID] = record
 	return nil

--- a/pkg/memory/store/in_memory_store_test.go
+++ b/pkg/memory/store/in_memory_store_test.go
@@ -1,0 +1,42 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Raezil/go-agent-development-kit/pkg/memory/model"
+)
+
+func TestInMemoryStoreUsesMatrixVectorWhenEmbeddingMissing(t *testing.T) {
+	store := NewInMemoryStore()
+	metadata := map[string]any{
+		model.EmbeddingMatrixKey: []any{
+			[]any{0.1, 0.2, 0.3},
+			[]any{},
+		},
+	}
+
+	if err := store.StoreMemory(context.Background(), "session", "content", metadata, nil); err != nil {
+		t.Fatalf("StoreMemory returned error: %v", err)
+	}
+
+	if len(store.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(store.records))
+	}
+
+	var rec model.MemoryRecord
+	for _, r := range store.records {
+		rec = r
+		break
+	}
+
+	if len(rec.Embedding) == 0 {
+		t.Fatalf("expected fallback embedding to be populated")
+	}
+	if len(rec.EmbeddingMatrix) != 1 {
+		t.Fatalf("expected sanitized embedding matrix, got %#v", rec.EmbeddingMatrix)
+	}
+	if rec.Embedding[0] != 0.1 || rec.Embedding[1] != 0.2 || rec.Embedding[2] != 0.3 {
+		t.Fatalf("unexpected fallback embedding: %#v", rec.Embedding)
+	}
+}

--- a/pkg/memory/store/mongodb_store.go
+++ b/pkg/memory/store/mongodb_store.go
@@ -66,6 +66,16 @@ func (ms *MongoStore) StoreMemory(ctx context.Context, sessionID, content string
 	}
 	edges := model.ValidGraphEdges(meta)
 	matrix := model.ValidEmbeddingMatrix(meta)
+	storedEmbedding := append([]float32(nil), embedding...)
+	if len(storedEmbedding) == 0 {
+		for _, vec := range matrix {
+			if len(vec) == 0 {
+				continue
+			}
+			storedEmbedding = append([]float32(nil), vec...)
+			break
+		}
+	}
 
 	id, err := ms.nextID(ctx)
 	if err != nil {
@@ -78,7 +88,7 @@ func (ms *MongoStore) StoreMemory(ctx context.Context, sessionID, content string
 		"space":         space,
 		"content":       content,
 		"metadata":      metadataJSON,
-		"embedding":     float64Embedding(embedding),
+		"embedding":     float64Embedding(storedEmbedding),
 		"importance":    importance,
 		"source":        source,
 		"summary":       summary,

--- a/pkg/memory/store/qdrant_store.go
+++ b/pkg/memory/store/qdrant_store.go
@@ -247,6 +247,17 @@ func (qs *QdrantStore) StoreMemory(ctx context.Context, sessionID, content strin
 	if space == "" {
 		space = sessionID
 	}
+	matrix := model.ValidEmbeddingMatrix(metaMap)
+	storedEmbedding := append([]float32(nil), embedding...)
+	if len(storedEmbedding) == 0 {
+		for _, vec := range matrix {
+			if len(vec) == 0 {
+				continue
+			}
+			storedEmbedding = append([]float32(nil), vec...)
+			break
+		}
+	}
 	payload := map[string]any{
 		"session_id":    sessionID,
 		"content":       content,
@@ -265,14 +276,14 @@ func (qs *QdrantStore) StoreMemory(ctx context.Context, sessionID, content strin
 	} else {
 		payload["graph_edges"] = edges
 	}
-	if matrix := model.ValidEmbeddingMatrix(metaMap); len(matrix) > 0 {
+	if len(matrix) > 0 {
 		payload[model.EmbeddingMatrixKey] = matrix
 	}
 	pointID := qs.generateID()
 	req := map[string]any{
 		"points": []map[string]any{{
 			"id":      pointID,
-			"vector":  embedding,
+			"vector":  storedEmbedding,
 			"payload": payload,
 		}},
 	}


### PR DESCRIPTION
## Summary
- populate stored embeddings from the first vector in the embedding matrix when the primary embedding is empty across the in-memory, Postgres, MongoDB, and Qdrant stores
- keep the sanitized embedding matrix on the record after normalization for consistent downstream use
- add a regression test that confirms the in-memory store backfills the embedding from matrix metadata
