### PR TITLE
Add Neo4j-backed graph store

### DIFF
--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -36,6 +36,7 @@ type (
 	InMemoryStore           = storepkg.InMemoryStore
 	PostgresStore           = storepkg.PostgresStore
 	QdrantStore             = storepkg.QdrantStore
+	Neo4jStore              = storepkg.Neo4jStore
 	Distance                = storepkg.Distance
 	CreateCollectionRequest = storepkg.CreateCollectionRequest
 
@@ -75,4 +76,5 @@ var (
 	NewInMemoryStore = storepkg.NewInMemoryStore
 	NewPostgresStore = storepkg.NewPostgresStore
 	NewQdrantStore   = storepkg.NewQdrantStore
+	NewNeo4jStore    = storepkg.NewNeo4jStore
 )

--- a/pkg/memory/store/neo4j_driver_adapter.go
+++ b/pkg/memory/store/neo4j_driver_adapter.go
@@ -1,0 +1,123 @@
+//go:build neo4j
+
+package store
+
+import (
+	"context"
+
+	neo4j "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+type driverWrapper struct {
+	driver neo4j.DriverWithContext
+}
+
+// WrapNeo4jDriver adapts the official Neo4j Go driver so it can be used with NewNeo4jStore.
+func WrapNeo4jDriver(driver neo4j.DriverWithContext) neo4jDriver {
+	if driver == nil {
+		return nil
+	}
+	return &driverWrapper{driver: driver}
+}
+
+func (d *driverWrapper) NewSession(ctx context.Context, config Neo4jSessionConfig) (neo4jSession, error) {
+	sessionConfig := neo4j.SessionConfig{DatabaseName: config.DatabaseName}
+	switch config.AccessMode {
+	case AccessModeWrite:
+		sessionConfig.AccessMode = neo4j.AccessModeWrite
+	case AccessModeRead:
+		sessionConfig.AccessMode = neo4j.AccessModeRead
+	}
+	session, err := d.driver.NewSession(ctx, sessionConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &sessionWrapper{session: session}, nil
+}
+
+func (d *driverWrapper) Close(ctx context.Context) error {
+	return d.driver.Close(ctx)
+}
+
+type sessionWrapper struct {
+	session neo4j.SessionWithContext
+}
+
+func (s *sessionWrapper) BeginTransaction(ctx context.Context) (neo4jTransaction, error) {
+	tx, err := s.session.BeginTransaction(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &transactionWrapper{tx: tx}, nil
+}
+
+func (s *sessionWrapper) Run(ctx context.Context, query string, params map[string]any) (neo4jResult, error) {
+	res, err := s.session.Run(ctx, query, params)
+	if err != nil {
+		return nil, err
+	}
+	return &resultWrapper{result: res}, nil
+}
+
+func (s *sessionWrapper) Close(ctx context.Context) error {
+	return s.session.Close(ctx)
+}
+
+type transactionWrapper struct {
+	tx neo4j.ExplicitTransaction
+}
+
+func (t *transactionWrapper) Run(ctx context.Context, query string, params map[string]any) (neo4jResult, error) {
+	res, err := t.tx.Run(ctx, query, params)
+	if err != nil {
+		return nil, err
+	}
+	return &resultWrapper{result: res}, nil
+}
+
+func (t *transactionWrapper) Commit(ctx context.Context) error {
+	return t.tx.Commit(ctx)
+}
+
+func (t *transactionWrapper) Rollback(ctx context.Context) error {
+	return t.tx.Rollback(ctx)
+}
+
+func (t *transactionWrapper) Close(ctx context.Context) error {
+	return t.tx.Close(ctx)
+}
+
+type resultWrapper struct {
+	result neo4j.ResultWithContext
+}
+
+func (r *resultWrapper) Next(ctx context.Context) bool {
+	return r.result.Next(ctx)
+}
+
+func (r *resultWrapper) Record() neo4jRecord {
+	rec := r.result.Record()
+	if rec == nil {
+		return nil
+	}
+	return recordWrapper{record: rec}
+}
+
+func (r *resultWrapper) Err() error {
+	return r.result.Err()
+}
+
+func (r *resultWrapper) Close(ctx context.Context) error {
+	return r.result.Close(ctx)
+}
+
+type recordWrapper struct {
+	record *neo4j.Record
+}
+
+func (r recordWrapper) Get(key string) (any, bool) {
+	if r.record == nil {
+		return nil, false
+	}
+	return r.record.Get(key)
+}

--- a/pkg/memory/store/neo4j_store.go
+++ b/pkg/memory/store/neo4j_store.go
@@ -1,0 +1,471 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Raezil/lattice-agent/pkg/memory/model"
+)
+
+// Neo4jAccessMode controls whether a session is opened for read or write operations.
+type Neo4jAccessMode string
+
+const (
+	// AccessModeWrite opens a session with write access.
+	AccessModeWrite Neo4jAccessMode = "write"
+	// AccessModeRead opens a session with read access.
+	AccessModeRead Neo4jAccessMode = "read"
+)
+
+// Neo4jSessionConfig mirrors the minimal subset of Neo4j session configuration we require.
+type Neo4jSessionConfig struct {
+	AccessMode   Neo4jAccessMode
+	DatabaseName string
+}
+
+// neo4jDriver abstracts the Neo4j driver capabilities used by the store. This allows tests to
+// provide lightweight fakes without depending on the real driver package (which is guarded behind
+// an optional build tag).
+type neo4jDriver interface {
+	NewSession(ctx context.Context, config Neo4jSessionConfig) (neo4jSession, error)
+	Close(ctx context.Context) error
+}
+
+type neo4jSession interface {
+	BeginTransaction(ctx context.Context) (neo4jTransaction, error)
+	Run(ctx context.Context, query string, params map[string]any) (neo4jResult, error)
+	Close(ctx context.Context) error
+}
+
+type neo4jTransaction interface {
+	Run(ctx context.Context, query string, params map[string]any) (neo4jResult, error)
+	Commit(ctx context.Context) error
+	Rollback(ctx context.Context) error
+	Close(ctx context.Context) error
+}
+
+type neo4jResult interface {
+	Next(ctx context.Context) bool
+	Record() neo4jRecord
+	Err() error
+	Close(ctx context.Context) error
+}
+
+type neo4jRecord interface {
+	Get(key string) (any, bool)
+}
+
+// Neo4jStore composes an existing VectorStore with a Neo4j-backed knowledge graph implementation.
+//
+// Vector embeddings and similarity search remain delegated to the base store, while graph specific
+// operations are persisted inside Neo4j.
+type Neo4jStore struct {
+	base     VectorStore
+	driver   neo4jDriver
+	database string
+	nowFn    func() time.Time
+}
+
+var (
+	_ VectorStore = (*Neo4jStore)(nil)
+	_ GraphStore  = (*Neo4jStore)(nil)
+)
+
+// ErrNeo4jUnavailable is returned when graph operations are attempted without a configured driver.
+var ErrNeo4jUnavailable = errors.New("neo4j driver not configured")
+
+// NewNeo4jStore constructs a store that delegates vector operations to base and uses the provided
+// Neo4j driver for graph persistence.
+func NewNeo4jStore(base VectorStore, driver neo4jDriver, database string) (*Neo4jStore, error) {
+	if base == nil {
+		return nil, errors.New("base vector store is nil")
+	}
+	if driver == nil {
+		return nil, errors.New("neo4j driver is nil")
+	}
+	return &Neo4jStore{base: base, driver: driver, database: database, nowFn: time.Now}, nil
+}
+
+// StoreMemory forwards the call to the underlying vector store.
+func (s *Neo4jStore) StoreMemory(ctx context.Context, sessionID, content string, metadata map[string]any, embedding []float32) error {
+	return s.base.StoreMemory(ctx, sessionID, content, metadata, embedding)
+}
+
+// SearchMemory forwards the call to the underlying vector store.
+func (s *Neo4jStore) SearchMemory(ctx context.Context, queryEmbedding []float32, limit int) ([]model.MemoryRecord, error) {
+	return s.base.SearchMemory(ctx, queryEmbedding, limit)
+}
+
+// UpdateEmbedding forwards the call to the underlying vector store.
+func (s *Neo4jStore) UpdateEmbedding(ctx context.Context, id int64, embedding []float32, lastEmbedded time.Time) error {
+	return s.base.UpdateEmbedding(ctx, id, embedding, lastEmbedded)
+}
+
+// DeleteMemory forwards the call to the underlying vector store.
+func (s *Neo4jStore) DeleteMemory(ctx context.Context, ids []int64) error {
+	return s.base.DeleteMemory(ctx, ids)
+}
+
+// Iterate forwards the call to the underlying vector store.
+func (s *Neo4jStore) Iterate(ctx context.Context, fn func(model.MemoryRecord) bool) error {
+	return s.base.Iterate(ctx, fn)
+}
+
+// Count forwards the call to the underlying vector store.
+func (s *Neo4jStore) Count(ctx context.Context) (int, error) {
+	return s.base.Count(ctx)
+}
+
+// CreateSchema delegates to the base store if it exposes SchemaInitializer and ensures Neo4j graph
+// constraints are present.
+func (s *Neo4jStore) CreateSchema(ctx context.Context, schemaPath string) error {
+	if initializer, ok := s.base.(SchemaInitializer); ok {
+		if err := initializer.CreateSchema(ctx, schemaPath); err != nil {
+			return err
+		}
+	}
+	if s.driver == nil {
+		return nil
+	}
+	session, err := s.driver.NewSession(ctx, Neo4jSessionConfig{AccessMode: AccessModeWrite, DatabaseName: s.database})
+	if err != nil {
+		return fmt.Errorf("neo4j new session: %w", err)
+	}
+	defer session.Close(ctx)
+	queries := []string{
+		"CREATE CONSTRAINT IF NOT EXISTS FOR (m:Memory) REQUIRE m.id IS UNIQUE",
+		"CREATE INDEX IF NOT EXISTS FOR (m:Memory) ON (m.space)",
+		"CREATE INDEX IF NOT EXISTS FOR ()-[r:RELATED_TO]-() ON (r.target_id)",
+	}
+	for _, query := range queries {
+		res, runErr := session.Run(ctx, query, nil)
+		if runErr != nil {
+			return fmt.Errorf("neo4j schema query: %w", runErr)
+		}
+		if res != nil {
+			_ = res.Close(ctx)
+		}
+	}
+	return nil
+}
+
+// Close releases both the base store (when it implements Close) and the Neo4j driver.
+func (s *Neo4jStore) Close() error {
+	var errs []string
+	if closer, ok := s.base.(interface{ Close() error }); ok {
+		if err := closer.Close(); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if s.driver != nil {
+		if err := s.driver.Close(context.Background()); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// UpsertGraph ensures the corresponding Memory node exists in Neo4j and refreshes its outgoing
+// relationships.
+func (s *Neo4jStore) UpsertGraph(ctx context.Context, record model.MemoryRecord, edges []model.GraphEdge) error {
+	if s.driver == nil {
+		return ErrNeo4jUnavailable
+	}
+	if record.ID == 0 {
+		return nil
+	}
+	session, err := s.driver.NewSession(ctx, Neo4jSessionConfig{AccessMode: AccessModeWrite, DatabaseName: s.database})
+	if err != nil {
+		return fmt.Errorf("neo4j new session: %w", err)
+	}
+	defer session.Close(ctx)
+	tx, err := session.BeginTransaction(ctx)
+	if err != nil {
+		return fmt.Errorf("neo4j begin tx: %w", err)
+	}
+	defer tx.Close(ctx)
+	now := s.now()
+	createdAt := record.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+	lastEmbedded := record.LastEmbedded
+	if lastEmbedded.IsZero() {
+		lastEmbedded = createdAt
+	}
+	space := normalizeSpace(record.Space, record.SessionID)
+	params := map[string]any{
+		"id":            record.ID,
+		"session_id":    record.SessionID,
+		"space":         space,
+		"content":       record.Content,
+		"metadata":      sanitizeMetadata(record.Metadata),
+		"importance":    record.Importance,
+		"source":        record.Source,
+		"summary":       record.Summary,
+		"created_at":    createdAt.UTC().Format(time.RFC3339Nano),
+		"last_embedded": lastEmbedded.UTC().Format(time.RFC3339Nano),
+		"updated_at":    now.UTC().Format(time.RFC3339Nano),
+	}
+	res, err := tx.Run(ctx, neo4jUpsertNodeCypher, params)
+	if err != nil {
+		tx.Rollback(ctx)
+		return fmt.Errorf("neo4j upsert node: %w", err)
+	}
+	if res != nil {
+		_ = res.Close(ctx)
+	}
+	res, err = tx.Run(ctx, "MATCH (m:Memory {id: $id})-[r:RELATED_TO]->() DELETE r", map[string]any{"id": record.ID})
+	if err != nil {
+		tx.Rollback(ctx)
+		return fmt.Errorf("neo4j delete edges: %w", err)
+	}
+	if res != nil {
+		_ = res.Close(ctx)
+	}
+	for _, edge := range edges {
+		if err := edge.Validate(); err != nil {
+			continue
+		}
+		edgeParams := map[string]any{
+			"from":       record.ID,
+			"target":     edge.Target,
+			"edge_type":  string(edge.Type),
+			"updated_at": now.UTC().Format(time.RFC3339Nano),
+			"space":      space,
+		}
+		res, err = tx.Run(ctx, neo4jUpsertEdgeCypher, edgeParams)
+		if err != nil {
+			tx.Rollback(ctx)
+			return fmt.Errorf("neo4j upsert edge: %w", err)
+		}
+		if res != nil {
+			_ = res.Close(ctx)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		tx.Rollback(ctx)
+		return fmt.Errorf("neo4j commit: %w", err)
+	}
+	return nil
+}
+
+// Neighborhood returns the nodes within the requested number of hops from the provided seeds.
+func (s *Neo4jStore) Neighborhood(ctx context.Context, seedIDs []int64, hops, limit int) ([]model.MemoryRecord, error) {
+	if s.driver == nil {
+		return nil, ErrNeo4jUnavailable
+	}
+	if len(seedIDs) == 0 || hops <= 0 || limit <= 0 {
+		return nil, nil
+	}
+	session, err := s.driver.NewSession(ctx, Neo4jSessionConfig{AccessMode: AccessModeRead, DatabaseName: s.database})
+	if err != nil {
+		return nil, fmt.Errorf("neo4j new session: %w", err)
+	}
+	defer session.Close(ctx)
+	params := map[string]any{
+		"seed_ids": seedIDs,
+		"hops":     hops,
+		"limit":    limit,
+	}
+	result, err := session.Run(ctx, neo4jNeighborhoodQuery, params)
+	if err != nil {
+		return nil, fmt.Errorf("neo4j neighborhood: %w", err)
+	}
+	defer result.Close(ctx)
+	records := make([]model.MemoryRecord, 0, limit)
+	for result.Next(ctx) {
+		rec, recErr := mapNeo4jRecord(result.Record())
+		if recErr != nil {
+			return nil, recErr
+		}
+		meta := model.DecodeMetadata(rec.Metadata)
+		model.HydrateRecordFromMetadata(&rec, meta)
+		if rec.Space == "" {
+			rec.Space = normalizeSpace("", rec.SessionID)
+		}
+		records = append(records, rec)
+	}
+	if err := result.Err(); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+func (s *Neo4jStore) now() time.Time {
+	if s == nil || s.nowFn == nil {
+		return time.Now().UTC()
+	}
+	return s.nowFn().UTC()
+}
+
+func sanitizeMetadata(meta string) string {
+	if strings.TrimSpace(meta) == "" {
+		return "{}"
+	}
+	return meta
+}
+
+func normalizeSpace(space, fallback string) string {
+	if strings.TrimSpace(space) != "" {
+		return strings.TrimSpace(space)
+	}
+	if strings.TrimSpace(fallback) != "" {
+		return strings.TrimSpace(fallback)
+	}
+	return "_shared"
+}
+
+const (
+	neo4jUpsertNodeCypher = `
+MERGE (m:Memory {id: $id})
+ON CREATE SET m.created_at = $created_at
+SET m.session_id = $session_id,
+    m.space = $space,
+    m.content = $content,
+    m.metadata = $metadata,
+    m.importance = $importance,
+    m.source = $source,
+    m.summary = $summary,
+    m.last_embedded = $last_embedded,
+    m.updated_at = $updated_at
+`
+	neo4jUpsertEdgeCypher = `
+MATCH (m:Memory {id: $from})
+MERGE (target:Memory {id: $target})
+ON CREATE SET target.space = COALESCE(target.space, $space)
+MERGE (m)-[r:RELATED_TO {target_id: $target}]->(target)
+SET r.edge_type = $edge_type,
+    r.updated_at = $updated_at
+`
+	neo4jNeighborhoodQuery = `
+UNWIND $seed_ids AS seed
+MATCH (start:Memory {id: seed})
+MATCH path=(start)-[:RELATED_TO*1..$hops]-(neighbor:Memory)
+WHERE NOT neighbor.id IN $seed_ids
+WITH neighbor, MIN(length(path)) AS depth
+RETURN neighbor.id AS id,
+       neighbor.session_id AS session_id,
+       neighbor.space AS space,
+       neighbor.content AS content,
+       neighbor.metadata AS metadata,
+       neighbor.importance AS importance,
+       neighbor.source AS source,
+       neighbor.summary AS summary,
+       neighbor.created_at AS created_at,
+       neighbor.last_embedded AS last_embedded
+ORDER BY depth ASC, neighbor.updated_at DESC
+LIMIT $limit
+`
+)
+
+func mapNeo4jRecord(rec neo4jRecord) (model.MemoryRecord, error) {
+	if rec == nil {
+		return model.MemoryRecord{}, errors.New("neo4j record is nil")
+	}
+	var out model.MemoryRecord
+	if v, ok := rec.Get("id"); ok {
+		out.ID = toInt64(v)
+	}
+	if v, ok := rec.Get("session_id"); ok {
+		out.SessionID = toString(v)
+	}
+	if v, ok := rec.Get("space"); ok {
+		out.Space = strings.TrimSpace(toString(v))
+	}
+	if v, ok := rec.Get("content"); ok {
+		out.Content = toString(v)
+	}
+	if v, ok := rec.Get("metadata"); ok {
+		out.Metadata = toString(v)
+	}
+	if v, ok := rec.Get("importance"); ok {
+		out.Importance = toFloat64(v)
+	}
+	if v, ok := rec.Get("source"); ok {
+		out.Source = toString(v)
+	}
+	if v, ok := rec.Get("summary"); ok {
+		out.Summary = toString(v)
+	}
+	if v, ok := rec.Get("created_at"); ok {
+		out.CreatedAt = parseTime(toString(v))
+	}
+	if v, ok := rec.Get("last_embedded"); ok {
+		out.LastEmbedded = parseTime(toString(v))
+	}
+	return out, nil
+}
+
+func toString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case fmt.Stringer:
+		return t.String()
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func toInt64(v any) int64 {
+	switch t := v.(type) {
+	case int:
+		return int64(t)
+	case int32:
+		return int64(t)
+	case int64:
+		return t
+	case float32:
+		return int64(t)
+	case float64:
+		return int64(t)
+	case jsonNumber:
+		if i, err := t.Int64(); err == nil {
+			return i
+		}
+	}
+	return 0
+}
+
+func toFloat64(v any) float64 {
+	switch t := v.(type) {
+	case float32:
+		return float64(t)
+	case float64:
+		return t
+	case int:
+		return float64(t)
+	case int64:
+		return float64(t)
+	case jsonNumber:
+		if f, err := t.Float64(); err == nil {
+			return f
+		}
+	}
+	return 0
+}
+
+func parseTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	if ts, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return ts
+	}
+	if ts, err := time.Parse(time.RFC3339, value); err == nil {
+		return ts
+	}
+	return time.Time{}
+}
+
+type jsonNumber interface {
+	Int64() (int64, error)
+	Float64() (float64, error)
+}

--- a/pkg/memory/store/neo4j_store_test.go
+++ b/pkg/memory/store/neo4j_store_test.go
@@ -1,0 +1,354 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Raezil/lattice-agent/pkg/memory/model"
+)
+
+type runCall struct {
+	query  string
+	params map[string]any
+}
+
+type fakeDriver struct {
+	writeSession *fakeSession
+	readSession  *fakeSession
+	configs      []Neo4jSessionConfig
+	closed       bool
+	closeErr     error
+}
+
+func (d *fakeDriver) NewSession(_ context.Context, config Neo4jSessionConfig) (neo4jSession, error) {
+	d.configs = append(d.configs, config)
+	switch config.AccessMode {
+	case AccessModeWrite:
+		if d.writeSession == nil {
+			d.writeSession = &fakeSession{}
+		}
+		return d.writeSession, nil
+	case AccessModeRead:
+		if d.readSession == nil {
+			d.readSession = &fakeSession{}
+		}
+		return d.readSession, nil
+	default:
+		return nil, errors.New("unknown access mode")
+	}
+}
+
+func (d *fakeDriver) Close(context.Context) error {
+	d.closed = true
+	return d.closeErr
+}
+
+type fakeSession struct {
+	tx       *fakeTx
+	runCalls []runCall
+	runErr   error
+	result   neo4jResult
+	closed   bool
+}
+
+func (s *fakeSession) BeginTransaction(context.Context) (neo4jTransaction, error) {
+	if s.tx == nil {
+		s.tx = &fakeTx{}
+	}
+	return s.tx, nil
+}
+
+func (s *fakeSession) Run(_ context.Context, query string, params map[string]any) (neo4jResult, error) {
+	s.runCalls = append(s.runCalls, runCall{query: query, params: params})
+	if s.runErr != nil {
+		return nil, s.runErr
+	}
+	if s.result != nil {
+		return s.result, nil
+	}
+	return &fakeResult{}, nil
+}
+
+func (s *fakeSession) Close(context.Context) error {
+	s.closed = true
+	return nil
+}
+
+type fakeTx struct {
+	runs        []runCall
+	runErrs     []error
+	commitErr   error
+	rollbackErr error
+	committed   bool
+	rolledBack  bool
+	closed      bool
+}
+
+func (tx *fakeTx) Run(_ context.Context, query string, params map[string]any) (neo4jResult, error) {
+	tx.runs = append(tx.runs, runCall{query: query, params: params})
+	if len(tx.runErrs) > 0 {
+		err := tx.runErrs[0]
+		tx.runErrs = tx.runErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &fakeResult{}, nil
+}
+
+func (tx *fakeTx) Commit(context.Context) error {
+	if tx.commitErr != nil {
+		return tx.commitErr
+	}
+	tx.committed = true
+	return nil
+}
+
+func (tx *fakeTx) Rollback(context.Context) error {
+	tx.rolledBack = true
+	return tx.rollbackErr
+}
+
+func (tx *fakeTx) Close(context.Context) error {
+	tx.closed = true
+	return nil
+}
+
+type fakeResult struct {
+	records []map[string]any
+	idx     int
+	err     error
+	closed  bool
+}
+
+func (r *fakeResult) Next(_ context.Context) bool {
+	if r.idx >= len(r.records) {
+		return false
+	}
+	r.idx++
+	return true
+}
+
+func (r *fakeResult) Record() neo4jRecord {
+	if r.idx == 0 || r.idx > len(r.records) {
+		return fakeRecord(nil)
+	}
+	return fakeRecord(r.records[r.idx-1])
+}
+
+func (r *fakeResult) Err() error { return r.err }
+
+func (r *fakeResult) Close(context.Context) error {
+	r.closed = true
+	return nil
+}
+
+type fakeRecord map[string]any
+
+func (r fakeRecord) Get(key string) (any, bool) {
+	if r == nil {
+		return nil, false
+	}
+	v, ok := r[key]
+	return v, ok
+}
+
+type schemaStore struct {
+	*InMemoryStore
+	schemaCalls int
+}
+
+func (s *schemaStore) CreateSchema(ctx context.Context, schemaPath string) error {
+	s.schemaCalls++
+	return nil
+}
+
+type closableInMemory struct {
+	*InMemoryStore
+	closed bool
+}
+
+func (c *closableInMemory) Close() error {
+	c.closed = true
+	return nil
+}
+
+func TestNewNeo4jStoreValidation(t *testing.T) {
+	base := NewInMemoryStore()
+	if _, err := NewNeo4jStore(nil, &fakeDriver{}, ""); err == nil {
+		t.Fatal("expected error when base store is nil")
+	}
+	if _, err := NewNeo4jStore(base, nil, ""); err == nil {
+		t.Fatal("expected error when driver is nil")
+	}
+}
+
+func TestNeo4jStoreUpsertGraph(t *testing.T) {
+	base := NewInMemoryStore()
+	driver := &fakeDriver{writeSession: &fakeSession{tx: &fakeTx{}}}
+	store, err := NewNeo4jStore(base, driver, "neo")
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	fixedNow := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
+	store.nowFn = func() time.Time { return fixedNow }
+	record := model.MemoryRecord{
+		ID:           42,
+		SessionID:    "session-1",
+		Content:      "memory",
+		Metadata:     "",
+		Importance:   0.75,
+		Source:       "test",
+		Summary:      "summary",
+		CreatedAt:    fixedNow.Add(-time.Hour),
+		LastEmbedded: fixedNow.Add(-30 * time.Minute),
+	}
+	edges := []model.GraphEdge{
+		{Target: 7, Type: model.EdgeFollows},
+		{Target: 0, Type: model.EdgeExplains}, // invalid and skipped
+	}
+	if err := store.UpsertGraph(context.Background(), record, edges); err != nil {
+		t.Fatalf("upsert graph: %v", err)
+	}
+	if len(driver.configs) == 0 || driver.configs[0].AccessMode != AccessModeWrite {
+		t.Fatalf("expected write session, configs=%v", driver.configs)
+	}
+	tx := driver.writeSession.tx
+	if tx == nil {
+		t.Fatalf("transaction not created")
+	}
+	if !tx.committed {
+		t.Fatalf("transaction not committed")
+	}
+	if len(tx.runs) != 3 {
+		t.Fatalf("expected 3 queries, got %d", len(tx.runs))
+	}
+	if tx.runs[0].query != neo4jUpsertNodeCypher {
+		t.Fatalf("unexpected first query: %s", tx.runs[0].query)
+	}
+	nodeParams := tx.runs[0].params
+	if got := nodeParams["metadata"].(string); got != "{}" {
+		t.Fatalf("expected metadata fallback, got %q", got)
+	}
+	if got := nodeParams["space"].(string); got != "session-1" {
+		t.Fatalf("expected space fallback to session, got %q", got)
+	}
+	if tx.runs[1].query != "MATCH (m:Memory {id: $id})-[r:RELATED_TO]->() DELETE r" {
+		t.Fatalf("unexpected delete query: %s", tx.runs[1].query)
+	}
+	if tx.runs[2].query != neo4jUpsertEdgeCypher {
+		t.Fatalf("unexpected edge query: %s", tx.runs[2].query)
+	}
+	if got := tx.runs[2].params["edge_type"].(string); got != string(model.EdgeFollows) {
+		t.Fatalf("unexpected edge type: %s", got)
+	}
+	if driver.writeSession.tx.rolledBack {
+		t.Fatalf("transaction should not roll back on success")
+	}
+}
+
+func TestNeo4jStoreNeighborhood(t *testing.T) {
+	base := NewInMemoryStore()
+	driver := &fakeDriver{readSession: &fakeSession{}}
+	store, err := NewNeo4jStore(base, driver, "neo")
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	driver.readSession.result = &fakeResult{
+		records: []map[string]any{
+			{
+				"id":            int64(7),
+				"session_id":    "session-1",
+				"space":         "",
+				"content":       "context",
+				"metadata":      `{"importance":0.9}`,
+				"importance":    0.9,
+				"source":        "system",
+				"summary":       "sum",
+				"created_at":    now,
+				"last_embedded": now,
+			},
+		},
+	}
+	neighbors, err := store.Neighborhood(context.Background(), []int64{42}, 2, 5)
+	if err != nil {
+		t.Fatalf("neighborhood: %v", err)
+	}
+	if len(neighbors) != 1 {
+		t.Fatalf("expected 1 neighbor, got %d", len(neighbors))
+	}
+	rec := neighbors[0]
+	if rec.ID != 7 {
+		t.Fatalf("unexpected neighbor id: %d", rec.ID)
+	}
+	if rec.Space != "session-1" {
+		t.Fatalf("expected space fallback to session, got %q", rec.Space)
+	}
+	if rec.Importance == 0 {
+		t.Fatalf("expected hydrated importance")
+	}
+	if rec.Content != "context" {
+		t.Fatalf("unexpected content: %s", rec.Content)
+	}
+	if rec.Metadata == "" {
+		t.Fatalf("expected metadata string")
+	}
+	if len(driver.configs) == 0 || driver.configs[0].AccessMode != AccessModeRead {
+		t.Fatalf("expected read session config, got %#v", driver.configs)
+	}
+}
+
+func TestNeo4jStoreCreateSchema(t *testing.T) {
+	base := &schemaStore{InMemoryStore: NewInMemoryStore()}
+	driver := &fakeDriver{writeSession: &fakeSession{}}
+	store, err := NewNeo4jStore(base, driver, "neo")
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	if err := store.CreateSchema(context.Background(), "ignored"); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	if base.schemaCalls != 1 {
+		t.Fatalf("expected schema initializer to be called once")
+	}
+	if len(driver.writeSession.runCalls) != 3 {
+		t.Fatalf("expected 3 schema queries, got %d", len(driver.writeSession.runCalls))
+	}
+	for i, call := range driver.writeSession.runCalls {
+		if call.params != nil {
+			t.Fatalf("expected schema query %d without params", i)
+		}
+	}
+}
+
+func TestNeo4jStoreClose(t *testing.T) {
+	base := &closableInMemory{InMemoryStore: NewInMemoryStore()}
+	driver := &fakeDriver{}
+	store, err := NewNeo4jStore(base, driver, "neo")
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if !base.closed {
+		t.Fatalf("expected base Close to be called")
+	}
+	if !driver.closed {
+		t.Fatalf("expected driver Close to be called")
+	}
+}
+
+func TestNeo4jUnavailable(t *testing.T) {
+	base := NewInMemoryStore()
+	store := &Neo4jStore{base: base}
+	if err := store.UpsertGraph(context.Background(), model.MemoryRecord{ID: 1}, nil); !errors.Is(err, ErrNeo4jUnavailable) {
+		t.Fatalf("expected ErrNeo4jUnavailable, got %v", err)
+	}
+	if _, err := store.Neighborhood(context.Background(), []int64{1}, 1, 1); !errors.Is(err, ErrNeo4jUnavailable) {
+		t.Fatalf("expected ErrNeo4jUnavailable, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Neo4j-backed graph layer that composes with existing vector stores
- provide optional adapter for the official Neo4j driver and update public aliases
- cover the new store with unit tests exercising schema, graph updates, and query behavior
