### PR TITLE
Add hybrid keyword-vector retrieval scoring

### DIFF
--- a/pkg/adk/kit_test.go
+++ b/pkg/adk/kit_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	DefaultMemorySimWeight        = 0.55
-	DefaultMemoryImportanceWeight = 0.25
-	DefaultMemoryRecencyWeight    = 0.15
+	DefaultMemorySimWeight        = 0.45
+	DefaultMemoryKeywordWeight    = 0.20
+	DefaultMemoryImportanceWeight = 0.20
+	DefaultMemoryRecencyWeight    = 0.10
 	DefaultMemorySourceWeight     = 0.05
 	DefaultMemoryMMRLambda        = 0.7
 	DefaultMemoryClusterSim       = 0.83
@@ -44,6 +45,7 @@ func DefaultMemoryOptions() memory.Options {
 	return memory.Options{
 		Weights: memory.ScoreWeights{
 			Similarity: DefaultMemorySimWeight,
+			Keywords:   DefaultMemoryKeywordWeight,
 			Importance: DefaultMemoryImportanceWeight,
 			Recency:    DefaultMemoryRecencyWeight,
 			Source:     DefaultMemorySourceWeight,

--- a/pkg/memory/engine/engine_test.go
+++ b/pkg/memory/engine/engine_test.go
@@ -13,7 +13,7 @@ func TestEngineWeightedRetrievalAndSummaries(t *testing.T) {
 	memStore := storepkg.NewInMemoryStore()
 	now := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	opts := Options{
-		Weights:  ScoreWeights{Similarity: 0.55, Importance: 0.25, Recency: 0.15, Source: 0.05},
+		Weights:  ScoreWeights{Similarity: 0.45, Keywords: 0.20, Importance: 0.20, Recency: 0.10, Source: 0.05},
 		HalfLife: 24 * time.Hour,
 		TTL:      720 * time.Hour,
 		SourceBoost: map[string]float64{
@@ -90,6 +90,43 @@ func TestEngineDeduplicationAndPrune(t *testing.T) {
 	}
 	if snap.TTLExpired == 0 {
 		t.Fatalf("expected TTL expiration metric to increment")
+	}
+}
+
+func TestEngineHybridKeywordBoost(t *testing.T) {
+	memStore := storepkg.NewInMemoryStore()
+	opts := Options{
+		Weights: ScoreWeights{
+			Similarity: 0.2,
+			Keywords:   0.6,
+			Importance: 0.1,
+			Recency:    0.05,
+			Source:     0.05,
+		},
+		HalfLife: 24 * time.Hour,
+	}
+	engine := NewEngine(memStore, opts).WithEmbedder(embedpkg.DummyEmbedder{})
+	ctx := context.Background()
+
+	if _, err := engine.Store(ctx, "team", "Marketing campaign launch checklist", map[string]any{"source": "notion"}); err != nil {
+		t.Fatalf("store marketing memory: %v", err)
+	}
+	if _, err := engine.Store(ctx, "team", "Investigate SAML login failure impacting enterprise customers", map[string]any{"source": "pagerduty"}); err != nil {
+		t.Fatalf("store incident memory: %v", err)
+	}
+
+	records, err := engine.Retrieve(ctx, "SAML login failure escalation", 2)
+	if err != nil {
+		t.Fatalf("retrieve: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+	if records[0].KeywordScore <= records[1].KeywordScore {
+		t.Fatalf("expected incident memory to rank higher on keywords: got %.2f vs %.2f", records[0].KeywordScore, records[1].KeywordScore)
+	}
+	if records[0].KeywordScore < 0.5 {
+		t.Fatalf("expected strong keyword match, got %.2f", records[0].KeywordScore)
 	}
 }
 

--- a/pkg/memory/engine/options.go
+++ b/pkg/memory/engine/options.go
@@ -5,6 +5,7 @@ import "time"
 // ScoreWeights controls the contribution of each scoring component during retrieval.
 type ScoreWeights struct {
 	Similarity float64
+	Keywords   float64
 	Importance float64
 	Recency    float64
 	Source     float64
@@ -31,9 +32,10 @@ type Options struct {
 func DefaultOptions() Options {
 	return Options{
 		Weights: ScoreWeights{
-			Similarity: 0.55,
-			Importance: 0.25,
-			Recency:    0.15,
+			Similarity: 0.45,
+			Keywords:   0.20,
+			Importance: 0.20,
+			Recency:    0.10,
 			Source:     0.05,
 		},
 		LambdaMMR:              0.7,
@@ -52,7 +54,7 @@ func DefaultOptions() Options {
 
 func (o Options) withDefaults() Options {
 	defaults := DefaultOptions()
-	if o.Weights.Similarity == 0 && o.Weights.Importance == 0 && o.Weights.Recency == 0 && o.Weights.Source == 0 {
+	if o.Weights.Similarity == 0 && o.Weights.Keywords == 0 && o.Weights.Importance == 0 && o.Weights.Recency == 0 && o.Weights.Source == 0 {
 		o.Weights = defaults.Weights
 	}
 	if o.LambdaMMR == 0 {
@@ -92,12 +94,13 @@ func (o Options) withDefaults() Options {
 }
 
 func (o Options) normalizedWeights() ScoreWeights {
-	total := o.Weights.Similarity + o.Weights.Importance + o.Weights.Recency + o.Weights.Source
+	total := o.Weights.Similarity + o.Weights.Keywords + o.Weights.Importance + o.Weights.Recency + o.Weights.Source
 	if total == 0 {
 		return o.Weights
 	}
 	return ScoreWeights{
 		Similarity: o.Weights.Similarity / total,
+		Keywords:   o.Weights.Keywords / total,
 		Importance: o.Weights.Importance / total,
 		Recency:    o.Weights.Recency / total,
 		Source:     o.Weights.Source / total,

--- a/pkg/memory/model/record.go
+++ b/pkg/memory/model/record.go
@@ -12,6 +12,7 @@ type MemoryRecord struct {
 	Embedding       []float32   `json:"embedding"`
 	EmbeddingMatrix [][]float32 `json:"embedding_matrix,omitempty"`
 	Score           float64     `json:"score"`
+	KeywordScore    float64     `json:"keyword_score"`
 	Importance      float64     `json:"importance"`
 	Source          string      `json:"source"`
 	Summary         string      `json:"summary"`


### PR DESCRIPTION
## Summary
- add lexical keyword extraction and scoring to retrieval so keyword matches boost ranking
- expose keyword score on memory records and adjust default score weights to include hybrid weighting
- add regression coverage for hybrid ranking and update default weight constants used in kit tests
