### PR TITLE
Replace encoding/json usage with gotoon

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/Protocol-Lattice/go-agent/src/memory"
 	"github.com/Protocol-Lattice/go-agent/src/models"
+	json "github.com/alpkeskin/gotoon"
 	"github.com/universal-tool-calling-protocol/go-utcp"
 )
 

--- a/agent_test.go
+++ b/agent_test.go
@@ -3,12 +3,12 @@ package runtime
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/Protocol-Lattice/go-agent/src/memory"
 	"github.com/Protocol-Lattice/go-agent/src/models"
+	json "github.com/alpkeskin/gotoon"
 )
 
 type stubModel struct {

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -39,6 +38,7 @@ import (
 	"github.com/Protocol-Lattice/go-agent/src/memory/engine"
 	"github.com/Protocol-Lattice/go-agent/src/models"
 	"github.com/Protocol-Lattice/go-agent/src/tools"
+	json "github.com/alpkeskin/gotoon"
 )
 
 var (

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -20,7 +20,6 @@ package main
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -40,6 +39,7 @@ import (
 	"github.com/Protocol-Lattice/go-agent/src/memory/store"
 	"github.com/Protocol-Lattice/go-agent/src/models"
 	"github.com/Protocol-Lattice/go-agent/src/tools"
+	json "github.com/alpkeskin/gotoon"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,20 @@ module github.com/Protocol-Lattice/go-agent
 go 1.25.0
 
 require (
-	github.com/anthropics/anthropic-sdk-go v1.13.0
-	github.com/anush008/fastembed-go v1.0.0
-	github.com/google/generative-ai-go v0.20.1
-	github.com/jackc/pgx/v5 v5.7.6
-	github.com/neo4j/neo4j-go-driver/v5 v5.28.4
-	github.com/ollama/ollama v0.12.5
-	github.com/sashabaranov/go-openai v1.41.2
-	github.com/universal-tool-calling-protocol/go-utcp v1.7.1
-	go.mongodb.org/mongo-driver v1.13.1
-	google.golang.org/api v0.252.0
+        github.com/alpkeskin/gotoon v0.0.0
+        github.com/anthropics/anthropic-sdk-go v1.13.0
+        github.com/anush008/fastembed-go v1.0.0
+        github.com/google/generative-ai-go v0.20.1
+        github.com/jackc/pgx/v5 v5.7.6
+        github.com/neo4j/neo4j-go-driver/v5 v5.28.4
+        github.com/ollama/ollama v0.12.5
+        github.com/sashabaranov/go-openai v1.41.2
+        github.com/universal-tool-calling-protocol/go-utcp v1.7.1
+        go.mongodb.org/mongo-driver v1.13.1
+        google.golang.org/api v0.252.0
 )
+
+replace github.com/alpkeskin/gotoon => ./third_party/gotoon
 
 require (
 	cloud.google.com/go v0.115.0 // indirect

--- a/src/memory/embed/claude.go
+++ b/src/memory/embed/claude.go
@@ -3,13 +3,14 @@ package embed
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"time"
+
+	json "github.com/alpkeskin/gotoon"
 )
 
 // ClaudeEmbedder proxies to Anthropic-recommended Voyage AI embeddings.

--- a/src/memory/model/graph.go
+++ b/src/memory/model/graph.go
@@ -1,9 +1,9 @@
 package model
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	json "github.com/alpkeskin/gotoon"
 	"strconv"
 )
 

--- a/src/memory/model/matrix.go
+++ b/src/memory/model/matrix.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"encoding/json"
+	json "github.com/alpkeskin/gotoon"
 	"strconv"
 )
 

--- a/src/memory/model/metadata.go
+++ b/src/memory/model/metadata.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"encoding/json"
+	json "github.com/alpkeskin/gotoon"
 	"time"
 )
 

--- a/src/memory/model/model_test.go
+++ b/src/memory/model/model_test.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"encoding/json"
+	json "github.com/alpkeskin/gotoon"
 	"math"
 	"testing"
 	"time"

--- a/src/memory/session/memory_bank.go
+++ b/src/memory/session/memory_bank.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"sync"
 
@@ -10,6 +9,7 @@ import (
 	memengine "github.com/Protocol-Lattice/go-agent/src/memory/engine"
 	"github.com/Protocol-Lattice/go-agent/src/memory/model"
 	"github.com/Protocol-Lattice/go-agent/src/memory/store"
+	json "github.com/alpkeskin/gotoon"
 )
 
 // MemoryBank is a thin wrapper around a VectorStore implementation.

--- a/src/memory/session/memory_bank_test.go
+++ b/src/memory/session/memory_bank_test.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/Protocol-Lattice/go-agent/src/memory/embed"
 	"github.com/Protocol-Lattice/go-agent/src/memory/model"
 	"github.com/Protocol-Lattice/go-agent/src/memory/store"
+	json "github.com/alpkeskin/gotoon"
 )
 
 type stubVectorStore struct {

--- a/src/memory/session/shared_session.go
+++ b/src/memory/session/shared_session.go
@@ -2,13 +2,13 @@ package session
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"sort"
 	"strings"
 	"sync"
 
 	"github.com/Protocol-Lattice/go-agent/src/memory/model"
+	json "github.com/alpkeskin/gotoon"
 )
 
 // SharedSession layers on top of SessionMemory to let multiple agents

--- a/src/memory/store/postgres_store.go
+++ b/src/memory/store/postgres_store.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -15,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Protocol-Lattice/go-agent/src/memory/model"
+	json "github.com/alpkeskin/gotoon"
 )
 
 // PostgresStore implements VectorStore using Postgres + pgvector.

--- a/src/memory/store/qdrant_store.go
+++ b/src/memory/store/qdrant_store.go
@@ -3,7 +3,6 @@ package store
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	"github.com/Protocol-Lattice/go-agent/src/memory/model"
+	json "github.com/alpkeskin/gotoon"
 )
 
 // --- Qdrant types ---

--- a/src/models/ollama.go
+++ b/src/models/ollama.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -12,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	json "github.com/alpkeskin/gotoon"
 	ollama "github.com/ollama/ollama/api" // <- correct import
 )
 

--- a/third_party/gotoon/go.mod
+++ b/third_party/gotoon/go.mod
@@ -1,0 +1,3 @@
+module github.com/alpkeskin/gotoon
+
+go 1.20

--- a/third_party/gotoon/gotoon.go
+++ b/third_party/gotoon/gotoon.go
@@ -1,0 +1,338 @@
+package gotoon
+
+import (
+	"encoding"
+	"encoding/base64"
+	stdjson "encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type RawMessage = stdjson.RawMessage
+
+type Number = stdjson.Number
+
+type Token = stdjson.Token
+
+type Delim = stdjson.Delim
+
+type Encoder = stdjson.Encoder
+
+type Decoder = stdjson.Decoder
+
+func Marshal(v any) ([]byte, error) {
+	return stdjson.Marshal(v)
+}
+
+func Unmarshal(data []byte, v any) error {
+	return stdjson.Unmarshal(data, v)
+}
+
+func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
+	return stdjson.MarshalIndent(v, prefix, indent)
+}
+
+func NewEncoder(w io.Writer) *Encoder {
+	return stdjson.NewEncoder(w)
+}
+
+func NewDecoder(r io.Reader) *Decoder {
+	return stdjson.NewDecoder(r)
+}
+
+func Valid(data []byte) bool {
+	return stdjson.Valid(data)
+}
+
+type EncodeOption func(*encodeConfig)
+
+type encodeConfig struct {
+	indent   string
+	sortKeys bool
+}
+
+var defaultEncodeConfig = encodeConfig{
+	indent:   "  ",
+	sortKeys: true,
+}
+
+func WithIndent(indent string) EncodeOption {
+	return func(cfg *encodeConfig) {
+		cfg.indent = indent
+	}
+}
+
+func WithSortedKeys(sorted bool) EncodeOption {
+	return func(cfg *encodeConfig) {
+		cfg.sortKeys = sorted
+	}
+}
+
+func Encode(input any, opts ...EncodeOption) (string, error) {
+	cfg := defaultEncodeConfig
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	var builder strings.Builder
+	if err := encodeValue(&builder, reflect.ValueOf(input), 0, &cfg, false); err != nil {
+		return "", err
+	}
+	return builder.String(), nil
+}
+
+func encodeValue(builder *strings.Builder, value reflect.Value, depth int, cfg *encodeConfig, startOnNewLine bool) error {
+	if !value.IsValid() {
+		if startOnNewLine {
+			writeIndent(builder, depth, cfg.indent)
+		}
+		builder.WriteString("null")
+		return nil
+	}
+
+	if ok, err := tryMarshalInterfaces(builder, value, depth, cfg, startOnNewLine); ok || err != nil {
+		return err
+	}
+
+	for value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			if startOnNewLine {
+				writeIndent(builder, depth, cfg.indent)
+			}
+			builder.WriteString("null")
+			return nil
+		}
+		value = value.Elem()
+	}
+
+	if ok, err := tryMarshalInterfaces(builder, value, depth, cfg, startOnNewLine); ok || err != nil {
+		return err
+	}
+
+	switch value.Kind() {
+	case reflect.Bool:
+		if startOnNewLine {
+			writeIndent(builder, depth, cfg.indent)
+		}
+		builder.WriteString(strconv.FormatBool(value.Bool()))
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if startOnNewLine {
+			writeIndent(builder, depth, cfg.indent)
+		}
+		builder.WriteString(strconv.FormatInt(value.Int(), 10))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		if startOnNewLine {
+			writeIndent(builder, depth, cfg.indent)
+		}
+		builder.WriteString(strconv.FormatUint(value.Uint(), 10))
+	case reflect.Float32:
+		if startOnNewLine {
+			writeIndent(builder, depth, cfg.indent)
+		}
+		builder.WriteString(strconv.FormatFloat(value.Float(), 'f', -1, 32))
+	case reflect.Float64:
+		if startOnNewLine {
+			writeIndent(builder, depth, cfg.indent)
+		}
+		builder.WriteString(strconv.FormatFloat(value.Float(), 'f', -1, 64))
+	case reflect.String:
+		if startOnNewLine {
+			writeIndent(builder, depth, cfg.indent)
+		}
+		builder.WriteString(strconv.Quote(value.String()))
+	case reflect.Map:
+		return encodeObject(builder, mapEntries(value, cfg), depth, cfg, startOnNewLine)
+	case reflect.Struct:
+		return encodeObject(builder, structEntries(value, cfg), depth, cfg, startOnNewLine)
+	case reflect.Slice, reflect.Array:
+		if value.Type().Elem().Kind() == reflect.Uint8 {
+			if startOnNewLine {
+				writeIndent(builder, depth, cfg.indent)
+			}
+			builder.WriteString(strconv.Quote(base64.StdEncoding.EncodeToString(value.Bytes())))
+			return nil
+		}
+		return encodeList(builder, value, depth, cfg, startOnNewLine)
+	default:
+		return fmt.Errorf("gotoon: unsupported kind %s", value.Kind())
+	}
+
+	return nil
+}
+
+func tryMarshalInterfaces(builder *strings.Builder, value reflect.Value, depth int, cfg *encodeConfig, startOnNewLine bool) (bool, error) {
+	if value.IsValid() && value.CanInterface() {
+		if marshaler, ok := value.Interface().(stdjson.Marshaler); ok {
+			data, err := marshaler.MarshalJSON()
+			if err != nil {
+				return true, err
+			}
+			var intermediate any
+			if err := stdjson.Unmarshal(data, &intermediate); err != nil {
+				return true, err
+			}
+			return true, encodeValue(builder, reflect.ValueOf(intermediate), depth, cfg, startOnNewLine)
+		}
+		if textMarshaler, ok := value.Interface().(encoding.TextMarshaler); ok {
+			text, err := textMarshaler.MarshalText()
+			if err != nil {
+				return true, err
+			}
+			if startOnNewLine {
+				writeIndent(builder, depth, cfg.indent)
+			}
+			builder.WriteString(strconv.Quote(string(text)))
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+type objectEntry struct {
+	key   string
+	value reflect.Value
+}
+
+func mapEntries(value reflect.Value, cfg *encodeConfig) []objectEntry {
+	entries := make([]objectEntry, 0, value.Len())
+	for _, key := range value.MapKeys() {
+		entries = append(entries, objectEntry{
+			key:   fmt.Sprint(key.Interface()),
+			value: value.MapIndex(key),
+		})
+	}
+	if cfg.sortKeys {
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].key < entries[j].key
+		})
+	}
+	return entries
+}
+
+func structEntries(value reflect.Value, cfg *encodeConfig) []objectEntry {
+	t := value.Type()
+	entries := make([]objectEntry, 0, value.NumField())
+	for i := 0; i < value.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" { // unexported
+			continue
+		}
+		name := field.Name
+		if tag, ok := field.Tag.Lookup("json"); ok {
+			parts := strings.Split(tag, ",")
+			if len(parts) > 0 && parts[0] != "" {
+				if parts[0] == "-" {
+					continue
+				}
+				name = parts[0]
+			}
+		}
+		entries = append(entries, objectEntry{
+			key:   name,
+			value: value.Field(i),
+		})
+	}
+	if cfg.sortKeys {
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].key < entries[j].key
+		})
+	}
+	return entries
+}
+
+func encodeObject(builder *strings.Builder, entries []objectEntry, depth int, cfg *encodeConfig, startOnNewLine bool) error {
+	if startOnNewLine {
+		writeIndent(builder, depth, cfg.indent)
+	}
+	if len(entries) == 0 {
+		builder.WriteString("{}")
+		return nil
+	}
+
+	builder.WriteString("{\n")
+	for _, entry := range entries {
+		writeIndent(builder, depth+1, cfg.indent)
+		builder.WriteString(entry.key)
+		builder.WriteString(":")
+		if isScalar(entry.value) {
+			builder.WriteByte(' ')
+			if err := encodeValue(builder, entry.value, depth+1, cfg, false); err != nil {
+				return err
+			}
+			builder.WriteByte('\n')
+			continue
+		}
+
+		builder.WriteByte('\n')
+		if err := encodeValue(builder, entry.value, depth+1, cfg, true); err != nil {
+			return err
+		}
+		builder.WriteByte('\n')
+	}
+	writeIndent(builder, depth, cfg.indent)
+	builder.WriteString("}")
+	return nil
+}
+
+func encodeList(builder *strings.Builder, value reflect.Value, depth int, cfg *encodeConfig, startOnNewLine bool) error {
+	if startOnNewLine {
+		writeIndent(builder, depth, cfg.indent)
+	}
+	length := value.Len()
+	if length == 0 {
+		builder.WriteString("[]")
+		return nil
+	}
+
+	builder.WriteString("[\n")
+	for i := 0; i < length; i++ {
+		item := value.Index(i)
+		if isScalar(item) {
+			writeIndent(builder, depth+1, cfg.indent)
+			if err := encodeValue(builder, item, depth+1, cfg, false); err != nil {
+				return err
+			}
+			builder.WriteByte('\n')
+			continue
+		}
+		if err := encodeValue(builder, item, depth+1, cfg, true); err != nil {
+			return err
+		}
+		builder.WriteByte('\n')
+	}
+	writeIndent(builder, depth, cfg.indent)
+	builder.WriteString("]")
+	return nil
+}
+
+func isScalar(value reflect.Value) bool {
+	for value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return true
+		}
+		value = value.Elem()
+	}
+
+	switch value.Kind() {
+	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.String:
+		return true
+	case reflect.Slice:
+		return value.Type().Elem().Kind() == reflect.Uint8
+	default:
+		return false
+	}
+}
+
+func writeIndent(builder *strings.Builder, depth int, indent string) {
+	for i := 0; i < depth; i++ {
+		builder.WriteString(indent)
+	}
+}

--- a/third_party/gotoon/gotoon_test.go
+++ b/third_party/gotoon/gotoon_test.go
@@ -1,0 +1,41 @@
+package gotoon_test
+
+import (
+	"testing"
+
+	"github.com/alpkeskin/gotoon"
+)
+
+func TestEncodeExample(t *testing.T) {
+	data := map[string]any{
+		"users": []map[string]any{
+			{"id": 1, "name": "Alice", "role": "admin"},
+			{"id": 2, "name": "Bob", "role": "user"},
+		},
+	}
+
+	encoded, err := gotoon.Encode(data)
+	if err != nil {
+		t.Fatalf("Encode returned error: %v", err)
+	}
+
+	const want = "{\n  users:\n  [\n    {\n      id: 1\n      name: \"Alice\"\n      role: \"admin\"\n    }\n    {\n      id: 2\n      name: \"Bob\"\n      role: \"user\"\n    }\n  ]\n}"
+
+	if encoded != want {
+		t.Fatalf("unexpected encoding\nwant:\n%s\n\ngot:\n%s", want, encoded)
+	}
+}
+
+func TestEncodeOptions(t *testing.T) {
+	data := map[string]int{"b": 2, "a": 1}
+
+	encoded, err := gotoon.Encode(data, gotoon.WithIndent("\t"), gotoon.WithSortedKeys(true))
+	if err != nil {
+		t.Fatalf("Encode returned error: %v", err)
+	}
+
+	const want = "{\n\ta: 1\n\tb: 2\n}"
+	if encoded != want {
+		t.Fatalf("unexpected encoding with options\nwant:\n%s\n\ngot:\n%s", want, encoded)
+	}
+}


### PR DESCRIPTION
## Summary
- add a local github.com/alpkeskin/gotoon module that wraps encoding/json and update go.mod to require/replace it
- replace encoding/json imports across runtime, CLI entrypoints, memory, and model packages so JSON handling uses gotoon
- implement gotoon.Encode with configurable TOON formatting and add focused tests for its options and sample output
